### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -309,7 +309,13 @@ TxtRotate.prototype.tick = function() {
     this.txt = fullTxt.substring(0, this.txt.length + 1);
   }
 
-  this.el.innerHTML = '<span class="wrap">'+this.txt+'</span>';
+  var wrapSpan = this.el.querySelector('.wrap');
+  if (!wrapSpan) {
+    wrapSpan = document.createElement('span');
+    wrapSpan.className = 'wrap';
+    this.el.appendChild(wrapSpan);
+  }
+  wrapSpan.textContent = this.txt;
 
   var that = this;
   var delta = 300 - Math.random() * 100;


### PR DESCRIPTION
Potential fix for [https://github.com/AjayaDahal/ajayadahal.github.io/security/code-scanning/1](https://github.com/AjayaDahal/ajayadahal.github.io/security/code-scanning/1)

In general, to fix this class of problem you must not insert untrusted text into the DOM using `innerHTML` (or similar APIs that parse HTML) without first performing appropriate escaping or, preferably, by using text node APIs (`textContent`, `createTextNode`, `appendChild`) so that the browser treats the data as literal text rather than markup.

For this specific code, the safest, least-invasive fix is to stop building an HTML string with `this.txt` and instead create/manage an inner `<span class="wrap">` element whose text content is set using `textContent`. The `class="wrap"` part is static and can safely remain as markup; the dynamic portion `this.txt` must never be interpreted as HTML. A straightforward change inside `TxtRotate.prototype.tick` is:

- Replace `this.el.innerHTML = '<span class="wrap">'+this.txt+'</span>';` with code that:
  - Looks for an existing child element with class `wrap` inside `this.el`.
  - If it doesn’t exist, creates a new `<span>` element, assigns it the `wrap` class, and appends it to `this.el`.
  - Sets the span’s `textContent` to `this.txt`.

This preserves all existing behavior (the animation and the `wrap` styling) but eliminates XSS risk by ensuring `this.txt` is handled as pure text. All required APIs (`querySelector`, `createElement`, `appendChild`, `textContent`) are standard DOM APIs, so no new imports or dependencies are needed. The only code change is within `js/main.js` around line 312.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
