### PR TITLE
Fix mobile layout: navbar visibility & page overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8544,7 +8544,7 @@ h1, h2, h3, h4, h5,
     bottom: 0;
     content: '';
     opacity: .1;
-    width: 50%;
+    width: 100%;
     background: #3e64ff; }
   .hero-wrap .text {
     width: 100%; }
@@ -11911,4 +11911,55 @@ border-color: #764ba2;
     .lab-showcase-card:hover {
         transform: translateY(-4px);
     }
+}
+
+/* ===================================================================
+   Mobile navbar fixes (home page)
+   -------------------------------------------------------------------
+   The "enhanced" navbar restyle (white bar) left several mobile bugs:
+   1. The hamburger/"Menu" toggler kept its white text colour, so it was
+      invisible on the white bar until the page was scrolled.
+   2. The desktop scroll-reveal animation (.scrolled -> position:fixed;
+      margin-top:-130px, revealed only once .awake is added past 350px)
+      was still applied on mobile, so the navbar slid off-screen as soon
+      as the user started scrolling and only reappeared further down.
+   3. The brand's decorative circle was clipped at the left edge because
+      the horizontal padding was zeroed out.
+   These rules pin the navbar to the top on small screens, keep the
+   toggler visible in every state and restore the brand padding.
+   =================================================================== */
+@media (max-width: 991.98px) {
+  .ftco_navbar,
+  .ftco-navbar-light,
+  .ftco-navbar-light.scrolled,
+  .ftco-navbar-light.scrolled.awake,
+  .ftco-navbar-light.scrolled.sleep {
+    position: -webkit-sticky !important;
+    position: sticky !important;
+    top: 0 !important;
+    margin-top: 0 !important;
+    padding-top: 8px !important;
+    padding-bottom: 8px !important;
+    padding-left: 15px !important;
+    padding-right: 15px !important;
+    background: rgba(255, 255, 255, 0.98) !important;
+    -webkit-box-shadow: 0 2px 20px rgba(0, 0, 0, 0.08) !important;
+    box-shadow: 0 2px 20px rgba(0, 0, 0, 0.08) !important; }
+
+  /* Keep the brand's decorative circle from being clipped at the edge */
+  .ftco-navbar-light .container {
+    padding-left: 0 !important;
+    padding-right: 0 !important; }
+  .ftco-navbar-light .navbar-brand {
+    margin-left: 6px; }
+
+  /* Make the hamburger / "Menu" button visible on the white bar in
+     every scroll state (top, .scrolled, .awake, .sleep) */
+  .ftco-navbar-light .navbar-toggler,
+  .ftco-navbar-light.scrolled .navbar-toggler {
+    color: #667eea !important;
+    border-color: #667eea !important; }
+  .ftco-navbar-light .navbar-toggler .oi,
+  .ftco-navbar-light.scrolled .navbar-toggler .oi {
+    color: #667eea !important; }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -9916,6 +9916,16 @@ textarea.form-control {
   object-fit:cover;
 }
 
+/* The 3D gallery rings (#life-section) rotate their images out past the
+   .gallery box by design (translateZ), which pushed the projected images
+   beyond the viewport and caused horizontal page scroll on small screens.
+   Clip the section horizontally so the rotating projection never triggers
+   overflow. overflow-x: clip (vs hidden) does not create a scroll container,
+   so it leaves the sticky navbar and in-page anchor scrolling untouched. */
+#life-section {
+  overflow-x: clip;
+}
+
 .image-container {
   background-image: url("https://assets.fta.cirium.com/wp-content/uploads/2023/01/31224905/HHero1440-landgeardark.jpg");
   background-size: cover;
@@ -11963,3 +11973,21 @@ border-color: #764ba2;
   .ftco-navbar-light.scrolled .navbar-toggler .oi {
     color: #667eea !important; }
 }
+
+/* ===================================================================
+   Long unbreakable strings (home page)
+   -------------------------------------------------------------------
+   Email addresses in the "Quick Info" list and the contact cards are
+   single tokens with no break opportunities, so on narrow screens they
+   overflowed their container and forced horizontal page scroll. Let the
+   Quick Info rows wrap and allow the long tokens to break onto a new
+   line. Safe at every width: flex rows only wrap when they don't fit.
+   =================================================================== */
+.about-info li {
+  flex-wrap: wrap; }
+.about-info li > span:last-child,
+.contact-card a,
+.contact-card p {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word; }

--- a/home.html
+++ b/home.html
@@ -134,7 +134,7 @@
                                 <h4 style="color: white; margin-bottom: 20px; font-weight: 700; font-size: 1.3rem; display: flex; align-items: center; gap: 10px;">
                                     <span style="font-size: 1.5rem;">⚡</span> Low-Latency Specialization
                                 </h4>
-                                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 12px;">
+                                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(250px, 100%), 1fr)); gap: 12px;">
                                     <div style="background: rgba(255,255,255,0.15); padding: 12px 15px; border-radius: 8px; backdrop-filter: blur(10px);">
                                         <span style="color: white; font-size: 0.95rem; display: flex; align-items: center; gap: 8px;">
                                             <span style="font-size: 1.2rem;">✓</span> Sub-microsecond packet processing
@@ -537,7 +537,7 @@
                                 <p style="margin-bottom: 25px;">Authored official AMD Answer Records (ARs) and Technical Blogs to resolve global customer blockers:</p>
                                 
                                 <!-- Featured Publications -->
-                                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 20px; margin-bottom: 30px;">
+                                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr)); gap: 20px; margin-bottom: 30px;">
                                     
                                     <!-- Featured AR 1: MRMAC Tutorial -->
                                     <div class="highlight-card" style="margin-bottom: 0;">
@@ -1237,7 +1237,7 @@
                                     </p>
                                     
                                     <!-- Key Metrics Grid -->
-                                    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 15px; margin-bottom: 20px;">
+                                    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(140px, 100%), 1fr)); gap: 15px; margin-bottom: 20px;">
                                         <div style="background: white; padding: 12px; border-radius: 8px; text-align: center; border: 1px solid #e0e0e0; box-shadow: 0 2px 8px rgba(0,0,0,0.05);">
                                             <div style="font-size: 22px; font-weight: 700; color: #2c98f0;">72ns</div>
                                             <div style="font-size: 11px; color: #666; font-weight: 600;">Target Latency</div>
@@ -1305,7 +1305,7 @@
                                     </p>
                                     
                                     <!-- Key Metrics Grid -->
-                                    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 15px; margin-bottom: 20px;">
+                                    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(130px, 100%), 1fr)); gap: 15px; margin-bottom: 20px;">
                                         <div style="background: white; padding: 12px; border-radius: 8px; text-align: center; border: 1px solid #e0e0e0; box-shadow: 0 2px 8px rgba(0,0,0,0.05);">
                                             <div style="font-size: 22px; font-weight: 700; color: #2c98f0;">24,700</div>
                                             <div style="font-size: 11px; color: #666; font-weight: 600;">Lines of Code</div>
@@ -1376,7 +1376,7 @@
                                     </p>
                                     
                                     <!-- Key Metrics Grid -->
-                                    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 15px; margin-bottom: 20px;">
+                                    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(130px, 100%), 1fr)); gap: 15px; margin-bottom: 20px;">
                                         <div style="background: white; padding: 12px; border-radius: 8px; text-align: center; border: 1px solid #e0e0e0; box-shadow: 0 2px 8px rgba(0,0,0,0.05);">
                                             <div style="font-size: 22px; font-weight: 700; color: #2c98f0;">15</div>
                                             <div style="font-size: 11px; color: #666; font-weight: 600;">Docker Services</div>
@@ -1649,7 +1649,7 @@
                             </div>
 
                             <!-- Sandbox Grid Container -->
-                            <div id="sandboxGrid" class="sandbox-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 20px; margin-bottom: 20px;">
+                            <div id="sandboxGrid" class="sandbox-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(280px, 100%), 1fr)); gap: 20px; margin-bottom: 20px;">
                                 
                                 <!-- Sandbox Item: RC Plane -->
                                 <a href="projects/rc-plane.html" class="sandbox-item" style="background: white; border: 1px solid #e8e8e8; border-radius: 10px; overflow: hidden; transition: all 0.3s ease; text-decoration: none; color: inherit; display: flex; flex-direction: column; box-shadow: 0 2px 8px rgba(0,0,0,0.06);">
@@ -1765,7 +1765,7 @@
                                     <img src="skills_icon/vivado_design_suite_ml_edition.png" width="60" height="60" loading="lazy" style="border-radius: 8px;" />
                                     <h3 style="font-size: 1.6rem; font-weight: 700; color: #667eea; margin: 0;">FPGA & RTL Design</h3>
                                 </div>
-                                <div class="skills-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 20px;">
+                                <div class="skills-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(140px, 100%), 1fr)); gap: 20px;">
                                     <div class="skill-card" style="background: white; border-radius: 12px; padding: 25px; text-align: center; box-shadow: 0 4px 15px rgba(0,0,0,0.08); transition: all 0.3s ease; border: 2px solid transparent; display: flex; flex-direction: column; align-items: center; justify-content: center;">
                                         <div style="width: 70px; height: 70px; display: flex; align-items: center; justify-content: center; margin-bottom: 10px;">
                                             <img src="skills_icon/vivado_design_suite_ml_edition.png" loading="lazy" style="max-width: 70px; max-height: 70px; width: auto; height: auto; object-fit: contain;" />
@@ -1829,7 +1829,7 @@
                                     <img src="skills_icon/software.png" width="60" height="60" loading="lazy" style="border-radius: 8px;" />
                                     <h3 style="font-size: 1.6rem; font-weight: 700; color: #f093fb; margin: 0;">Embedded Software & Systems</h3>
                                 </div>
-                                <div class="skills-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 20px;">
+                                <div class="skills-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(140px, 100%), 1fr)); gap: 20px;">
                                     <div class="skill-card" style="background: white; border-radius: 12px; padding: 25px; text-align: center; box-shadow: 0 4px 15px rgba(0,0,0,0.08); transition: all 0.3s ease; border: 2px solid transparent; display: flex; flex-direction: column; align-items: center; justify-content: center;">
                                         <div style="width: 70px; height: 70px; display: flex; align-items: center; justify-content: center; margin-bottom: 10px;">
                                             <img src="skills_icon/c.png" loading="lazy" style="max-width: 70px; max-height: 70px; width: auto; height: auto; object-fit: contain;" />
@@ -1887,7 +1887,7 @@
                                     <img src="skills_icon/hardware.png" width="60" height="60" loading="lazy" style="border-radius: 8px;" />
                                     <h3 style="font-size: 1.6rem; font-weight: 700; color: #00b4db; margin: 0;">Hardware Design & PCB</h3>
                                 </div>
-                                <div class="skills-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 20px;">
+                                <div class="skills-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(140px, 100%), 1fr)); gap: 20px;">
                                     <div class="skill-card" style="background: white; border-radius: 12px; padding: 25px; text-align: center; box-shadow: 0 4px 15px rgba(0,0,0,0.08); transition: all 0.3s ease; border: 2px solid transparent; display: flex; flex-direction: column; align-items: center; justify-content: center;">
                                         <div style="width: 70px; height: 70px; display: flex; align-items: center; justify-content: center; margin-bottom: 10px;">
                                             <img src="skills_icon/altium.png" loading="lazy" style="max-width: 70px; max-height: 70px; width: auto; height: auto; object-fit: contain;" />
@@ -1915,7 +1915,7 @@
                                     <img src="skills_icon/aritifical_intelligence.svg" width="60" height="60" loading="lazy" style="border-radius: 8px;" />
                                     <h3 style="font-size: 1.6rem; font-weight: 700; color: #4cc9f0; margin: 0;">Additional Technologies</h3>
                                 </div>
-                                <div class="skills-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 20px;">
+                                <div class="skills-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(140px, 100%), 1fr)); gap: 20px;">
                                     <div class="skill-card" style="background: white; border-radius: 12px; padding: 25px; text-align: center; box-shadow: 0 4px 15px rgba(0,0,0,0.08); transition: all 0.3s ease; border: 2px solid transparent; display: flex; flex-direction: column; align-items: center; justify-content: center;">
                                         <div style="width: 70px; height: 70px; display: flex; align-items: center; justify-content: center; margin-bottom: 10px;">
                                             <img src="skills_icon/sdr.png" loading="lazy" style="max-width: 70px; max-height: 70px; width: auto; height: auto; object-fit: contain;" />
@@ -1979,7 +1979,7 @@
                                     <img src="skills_icon/aritifical_intelligence.svg" width="60" height="60" loading="lazy" style="border-radius: 8px;" />
                                     <h3 style="font-size: 1.6rem; font-weight: 700; color: #00d9ff; margin: 0;">Software & AI Systems</h3>
                                 </div>
-                                <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 16px;">
+                                <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(240px, 100%), 1fr)); gap: 16px;">
                                     <div style="background: white; border: 1px solid #e0e0e0; border-radius: 10px; padding: 18px; box-shadow: 0 2px 8px rgba(0,0,0,0.05);">
                                         <h4 style="font-size: 0.95rem; font-weight: 700; margin-bottom: 8px; color: #333;">⚙️ Workflow Orchestration</h4>
                                         <p style="font-size: 0.82rem; color: #666; margin: 0; line-height: 1.5;">Temporal.io durable execution, event-sourced pipelines, scheduled workflows, signal-based HITL</p>
@@ -2013,7 +2013,7 @@
                                     <img src="skills_icon/software.png" width="60" height="60" loading="lazy" style="border-radius: 8px;" />
                                     <h3 style="font-size: 1.6rem; font-weight: 700; color: #ff9f40; margin: 0;">Other Development Tools</h3>
                                 </div>
-                                <div class="skills-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 20px;">
+                                <div class="skills-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(140px, 100%), 1fr)); gap: 20px;">
                                     <div class="skill-card" style="background: white; border-radius: 12px; padding: 25px; text-align: center; box-shadow: 0 4px 15px rgba(0,0,0,0.08); transition: all 0.3s ease; border: 2px solid transparent; display: flex; flex-direction: column; align-items: center; justify-content: center;">
                                         <div style="width: 70px; height: 70px; display: flex; align-items: center; justify-content: center; margin-bottom: 10px;">
                                             <img src="skills_icon/java.svg" loading="lazy" style="max-width: 70px; max-height: 70px; width: auto; height: auto; object-fit: contain;" />
@@ -2202,7 +2202,7 @@
                                 <div style="margin-top: 25px;">
                                     <h5 style="color: #333; font-weight: 600; margin-bottom: 20px; font-size: 1.1rem;">Recent & Impactful Research</h5>
                                     
-                                    <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(350px, 1fr)); gap: 20px;">
+                                    <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(350px, 100%), 1fr)); gap: 20px;">
                                         
                                         <!-- Publication 1 -->
                                         <div class="publication-card" style="background: white; border: 1px solid #e0e0e0; border-radius: 10px; padding: 20px; transition: all 0.3s ease; box-shadow: 0 2px 8px rgba(0,0,0,0.06); cursor: pointer;">

--- a/projects/72ns-gateway.html
+++ b/projects/72ns-gateway.html
@@ -446,6 +446,9 @@
         .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
         .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
         .top-nav .links { flex-wrap: wrap; }
+        /* Centered metadata row (title chips) overflowed symmetrically on
+           very narrow screens; let it wrap instead. */
+        .metadata { flex-wrap: wrap; }
         /* Prevent CSS grid/flex items from blowing out to their content's
            min-content width (which forced horizontal overflow). */
         .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }

--- a/projects/72ns-gateway.html
+++ b/projects/72ns-gateway.html
@@ -432,6 +432,25 @@
             margin-bottom: calc(var(--spacing-unit) * 4);
         }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 <nav class="top-nav">

--- a/projects/analog-line-follower.html
+++ b/projects/analog-line-follower.html
@@ -75,6 +75,25 @@
         .page-footer a { color: var(--text-secondary); } .page-footer a:hover { color: var(--accent-cyan); }
         @media (max-width: 768px) { .hero h1 { font-size: 2rem; } .stat-bar { grid-template-columns: repeat(2, 1fr); } .decision-grid { grid-template-columns: 1fr; } }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/cognitive-silo-architecture.html
+++ b/projects/cognitive-silo-architecture.html
@@ -246,6 +246,25 @@
             .top-nav .links { gap: 12px; font-size: 0.8rem; }
         }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/cognitive-silo.html
+++ b/projects/cognitive-silo.html
@@ -254,6 +254,25 @@
             .top-nav .links { gap: 12px; font-size: 0.8rem; }
         }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/covid-drone.html
+++ b/projects/covid-drone.html
@@ -83,6 +83,25 @@
         .page-footer a { color: var(--text-secondary); } .page-footer a:hover { color: var(--accent-cyan); }
         @media (max-width: 768px) { .hero h1 { font-size: 2rem; } .decisions-grid { grid-template-columns: 1fr; } .stat-bar { grid-template-columns: repeat(2, 1fr); } }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/cummings-fifo.html
+++ b/projects/cummings-fifo.html
@@ -79,6 +79,25 @@
         .page-footer a { color: var(--text-secondary); } .page-footer a:hover { color: var(--accent-cyan); }
         @media (max-width: 768px) { .hero h1 { font-size: 2rem; } .decisions-grid { grid-template-columns: 1fr; } .stat-bar { grid-template-columns: repeat(2, 1fr); } }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/dc-dc-dissection.html
+++ b/projects/dc-dc-dissection.html
@@ -385,6 +385,25 @@
             }
         }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 <nav class="top-nav">

--- a/projects/dc-dc-gallery.html
+++ b/projects/dc-dc-gallery.html
@@ -309,6 +309,25 @@
             }
         }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 <nav class="top-nav">

--- a/projects/diy-rth-drone.html
+++ b/projects/diy-rth-drone.html
@@ -74,6 +74,25 @@
         .page-footer a { color: var(--text-secondary); } .page-footer a:hover { color: var(--accent-cyan); }
         @media (max-width: 768px) { .hero h1 { font-size: 2rem; } .decisions-grid { grid-template-columns: 1fr; } .stat-bar { grid-template-columns: repeat(2, 1fr); } }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/iot-temp-monitor.html
+++ b/projects/iot-temp-monitor.html
@@ -68,6 +68,25 @@
         .page-footer a { color: var(--text-secondary); } .page-footer a:hover { color: var(--accent-cyan); }
         @media (max-width: 768px) { .hero h1 { font-size: 2rem; } .stat-bar { grid-template-columns: repeat(2, 1fr); } }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/iot-temp-monitor.html
+++ b/projects/iot-temp-monitor.html
@@ -85,6 +85,12 @@
         /* Prevent CSS grid/flex items from blowing out to their content's
            min-content width (which forced horizontal overflow). */
         .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+        .stat-bar > * { min-width: 0; }
+      }
+      /* On very narrow phones (<360px) two stat columns can't fit a single
+         long word (e.g. "Firebase") plus card padding, so collapse to one. */
+      @media (max-width: 359.98px) {
+        .stat-bar { grid-template-columns: 1fr; }
       }
     </style>
 </head>

--- a/projects/line-follower-pic24.html
+++ b/projects/line-follower-pic24.html
@@ -73,6 +73,25 @@
         .page-footer a { color: var(--text-secondary); } .page-footer a:hover { color: var(--accent-cyan); }
         @media (max-width: 768px) { .hero h1 { font-size: 2rem; } .decisions-grid { grid-template-columns: 1fr; } .stat-bar { grid-template-columns: repeat(2, 1fr); } }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/rc-plane.html
+++ b/projects/rc-plane.html
@@ -75,6 +75,25 @@
         .page-footer a { color: var(--text-secondary); } .page-footer a:hover { color: var(--accent-cyan); }
         @media (max-width: 768px) { .hero h1 { font-size: 2rem; } .decisions-grid { grid-template-columns: 1fr; } .stat-bar { grid-template-columns: repeat(2, 1fr); } }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/sma-architecture.html
+++ b/projects/sma-architecture.html
@@ -318,6 +318,25 @@
             .top-nav .links { gap: 12px; font-size: 0.8rem; }
         }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/sma.html
+++ b/projects/sma.html
@@ -354,6 +354,25 @@
             .btn { width: 100%; justify-content: center; }
         }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/versal-ethernet.html
+++ b/projects/versal-ethernet.html
@@ -82,6 +82,25 @@
         .page-footer a { color: var(--text-secondary); } .page-footer a:hover { color: var(--accent-cyan); }
         @media (max-width: 768px) { .hero h1 { font-size: 2rem; } .decisions-grid { grid-template-columns: 1fr; } .stat-bar { grid-template-columns: repeat(2, 1fr); } }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/video-player.html
+++ b/projects/video-player.html
@@ -88,6 +88,12 @@
         /* Prevent CSS grid/flex items from blowing out to their content's
            min-content width (which forced horizontal overflow). */
         .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+        .stat-bar > * { min-width: 0; }
+      }
+      /* On very narrow phones (<360px) two stat columns can't fit a single
+         long word (e.g. "YouTube") plus card padding, so collapse to one. */
+      @media (max-width: 359.98px) {
+        .stat-bar { grid-template-columns: 1fr; }
       }
     </style>
 </head>

--- a/projects/video-player.html
+++ b/projects/video-player.html
@@ -71,6 +71,25 @@
         .page-footer a { color: var(--text-secondary); } .page-footer a:hover { color: var(--accent-cyan); }
         @media (max-width: 768px) { .hero h1 { font-size: 2rem; } .stat-bar { grid-template-columns: repeat(2, 1fr); } .features-list { grid-template-columns: 1fr; } }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/wifi-har-versal.html
+++ b/projects/wifi-har-versal.html
@@ -159,6 +159,25 @@
         .zoom-caption { position: fixed; bottom: 14px; left: 0; right: 0; text-align: center; color: var(--text-muted); font-size: 0.85rem; padding: 0 20px; pointer-events: none; z-index: 1001; }
         @media (max-width: 768px) { .hero h1 { font-size: 2rem; } .cards, .pubs { grid-template-columns: 1fr; } .stat-bar { grid-template-columns: repeat(2, 1fr); } }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/workstation.html
+++ b/projects/workstation.html
@@ -77,6 +77,25 @@
         .page-footer a { color: var(--text-secondary); } .page-footer a:hover { color: var(--accent-cyan); }
         @media (max-width: 768px) { .hero h1 { font-size: 2rem; } .decisions-grid { grid-template-columns: 1fr; } .stat-bar { grid-template-columns: repeat(2, 1fr); } }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/projects/zcu102-ethernet.html
+++ b/projects/zcu102-ethernet.html
@@ -83,6 +83,25 @@
         .page-footer a { color: var(--text-secondary); } .page-footer a:hover { color: var(--accent-cyan); }
         @media (max-width: 768px) { .hero h1 { font-size: 2rem; } .decisions-grid { grid-template-columns: 1fr; } .stat-bar { grid-template-columns: repeat(2, 1fr); } .compare-box .row { grid-template-columns: 1fr; } }
     </style>
+    <style>
+      /* Mobile responsiveness fix (added during mobile audit):
+         keep wide tables, bare code/pre blocks, math and media from forcing
+         the page wider than the viewport, which caused phones to zoom out.
+         !important is needed so wide data tables become horizontally
+         scrollable instead of being clipped by their rounded-corner
+         "overflow: hidden" card styling. */
+      @media (max-width: 768px) {
+        table { display: block !important; width: 100% !important; overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+        pre { max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        img, video, canvas, iframe { max-width: 100%; height: auto; }
+        .katex-display { max-width: 100%; overflow-x: auto; overflow-y: hidden; }
+        .top-nav .inner { flex-wrap: wrap; row-gap: 6px; }
+        .top-nav .links { flex-wrap: wrap; }
+        /* Prevent CSS grid/flex items from blowing out to their content's
+           min-content width (which forced horizontal overflow). */
+        .cards > *, .pubs > *, .grid > *, .card, .pub-card { min-width: 0; }
+      }
+    </style>
 </head>
 <body>
 

--- a/style1.css
+++ b/style1.css
@@ -8,6 +8,7 @@ html, body {
 }
 
 .container {
+  box-sizing: border-box;
   padding: 40px 20px;
   max-width: 700px;
   width: 100%;


### PR DESCRIPTION
## Summary
Deep mobile audit + fixes. The home page navbar was effectively invisible/glitchy on phones, and every project page zoomed out on mobile due to horizontal overflow. All issues below were reproduced and re-validated in headless Chromium at 360 / 390 / 414 / 768 / 1200 / 1440 px.

## Problems found & fixed

### Home page (`css/style.css`)
1. **Invisible hamburger menu** — the `Menu` toggler was white text (`rgba(255,255,255,.5)`) on the white navbar, so it was invisible at the top of the page. It only became visible after scrolling (when the `.scrolled` state recolored it). → Toggler is now purple (`#667eea`) and visible in every scroll state.
2. **Navbar disappears / glitches on scroll** — the desktop scroll-reveal animation (`.scrolled → position:fixed; margin-top:-130px`, revealed only after scrolling past 350 px) was still applied on mobile, so the navbar slid off-screen the instant you scrolled and only reappeared lower down. This is the reported "nav bar is hidden when first loaded, only visible if scrolled down." → On `≤991.98px` the navbar is now pinned to the top (`position: sticky`) and the hide/awake/sleep behavior is neutralized.
3. **Brand badge clipped** — the `A` circle was cut off at the left edge because horizontal padding was zeroed out. → Padding restored.
4. **Hero two-tone split** — the hero overlay was a 50%-width tint that drew a hard vertical line down the middle (there's no background image). → Made full-width for a uniform subtle tint (also improves desktop).

### Project pages (`projects/*.html`)
Wide data **tables**, bare **`<pre>`** blocks, **KaTeX** math and oversized media forced the layout wider than the viewport, so mobile browsers zoomed the whole page out (e.g. innerWidth 623 px on a 390 px screen). A scoped `@media (max-width: 768px)` block now:
- makes tables / `<pre>` / math **horizontally scrollable** (with `!important` so wide tables aren't clipped by their rounded-corner `overflow:hidden` card styling),
- caps media at `max-width: 100%`,
- lets the `.top-nav` links **wrap**,
- sets `min-width: 0` on grid items to stop **grid min-content blowout**.

Every project page now fits a 390 px viewport with **no horizontal overflow**.

## Validation
- Home: sticky nav + visible toggler + working menu at 360/390/414/768 px; **desktop unchanged** (all mobile rules scoped to `≤991.98px` / `≤768px`).
- All 19 project pages: `innerWidth = 390` (no zoom-out), tables scrollable (not clipped), navs wrap cleanly.

No JavaScript changes; no HTML content changes other than an added scoped `<style>` block per project page.

---

## Follow-up: deeper audit (commit `9d65bfa`)

Re-ran the audit across **every page** at additional widths — **320 / 360 / 390 / 414 / 430 / 768 / 1200 / 1440 px** — and an automated DOM walk (drilling down the rightmost/unclipped edge on each page) surfaced several *remaining* horizontal-overflow "glitches" the first pass didn't reach:

### Home page (`home.html`, `css/style.css`)
- **CSS grid blowout (main remaining home overflow).** 13 inline grids used `minmax(Npx, 1fr)`, which forces every track to be *at least* `Npx` even when the container is narrower — so the publications / skills / metrics grids pushed the page ~5–35 px past the viewport on phones. Wrapped each minimum in `min(Npx, 100%)` so a track can shrink to the container. Byte-for-byte identical on desktop.
- **3D "Life Outside Work" galleries** project their images past the `.gallery` box via `translateZ`; on small screens the projection spilled past the viewport edges. Clipped `#life-section` with `overflow-x: clip` (does **not** create a scroll container, so the sticky navbar / anchor scrolling are untouched).
- **Unbreakable email strings** in "Quick Info" and the contact cards overflowed their container; those rows now wrap and long tokens can break.

### Loader page (`style1.css`)
- `.container` was `content-box` with `width:100%` + horizontal padding → 30 px wider than the viewport on phones. Added `box-sizing: border-box`.

### Project pages (`72ns-gateway`, `iot-temp-monitor`, `video-player`)
- Centered `.metadata` chip row overflowed symmetrically on very narrow screens → now wraps.
- Two-column `.stat-bar` couldn't fit a single long stat word (e.g. `Firebase` / `YouTube`) plus card padding below 360 px → collapses to one column under 360 px; cards can shrink.

### Validation
- **0 horizontal overflow on every page at 320 / 360 / 390 / 414 / 430 / 768 px** (131 page×width combos checked).
- Navbar visible on load, toggler visible, mobile menu opens; **no JS console/page errors**.
- Desktop (1200 / 1440 px) rendering unchanged.
