### PR TITLE
Add project page: NAND to Tetris on a Basys3 (Hack computer)

### DIFF
--- a/home.html
+++ b/home.html
@@ -1650,7 +1650,21 @@
 
                             <!-- Sandbox Grid Container -->
                             <div id="sandboxGrid" class="sandbox-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(280px, 100%), 1fr)); gap: 20px; margin-bottom: 20px;">
-                                
+
+                                <!-- Sandbox Item: NAND to Tetris on Basys3 -->
+                                <a href="projects/hack-computer-basys3.html" class="sandbox-item" style="background: white; border: 1px solid #e8e8e8; border-radius: 10px; overflow: hidden; transition: all 0.3s ease; text-decoration: none; color: inherit; display: flex; flex-direction: column; box-shadow: 0 2px 8px rgba(0,0,0,0.06);">
+                                    <img src="images/hack-nand2tetris.svg" style="width: 100%; height: 140px; object-fit: cover;" alt="NAND to Tetris on a Basys3" loading="lazy" />
+                                    <div style="padding: 16px;">
+                                        <span style="display: inline-block; font-size: 11px; font-weight: 600; color: #999; margin-bottom: 8px;">SEPTEMBER 2026 &middot; PLAYABLE IN BROWSER</span>
+                                        <h4 style="margin: 0 0 8px 0; font-size: 1.05rem; font-weight: 600; color: #333;">NAND to Tetris, on Real Silicon</h4>
+                                        <div style="display: flex; flex-wrap: wrap; gap: 6px;">
+                                            <span style="display: inline-block; background: #f0f4ff; color: #667eea; padding: 3px 8px; border-radius: 10px; font-size: 10px; font-weight: 500;">Nand2Tetris</span>
+                                            <span style="display: inline-block; background: #f0f4ff; color: #667eea; padding: 3px 8px; border-radius: 10px; font-size: 10px; font-weight: 500;">Basys3</span>
+                                            <span style="display: inline-block; background: #f0f4ff; color: #667eea; padding: 3px 8px; border-radius: 10px; font-size: 10px; font-weight: 500;">CPU Design</span>
+                                        </div>
+                                    </div>
+                                </a>
+
                                 <!-- Sandbox Item: RC Plane -->
                                 <a href="projects/rc-plane.html" class="sandbox-item" style="background: white; border: 1px solid #e8e8e8; border-radius: 10px; overflow: hidden; transition: all 0.3s ease; text-decoration: none; color: inherit; display: flex; flex-direction: column; box-shadow: 0 2px 8px rgba(0,0,0,0.06);">
                                     <img src="images/RC_plane.jpg" style="width: 100%; height: 140px; object-fit: cover;" loading="lazy" />

--- a/images/hack-nand2tetris.svg
+++ b/images/hack-nand2tetris.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 220" width="400" height="220" role="img" aria-label="NAND to Tetris on a Basys3">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0a0e14"/>
+      <stop offset="1" stop-color="#05070a"/>
+    </linearGradient>
+    <linearGradient id="acc" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#00d9ff"/>
+      <stop offset="1" stop-color="#00ff9f"/>
+    </linearGradient>
+    <filter id="glow"><feGaussianBlur stdDeviation="1.4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  </defs>
+  <rect width="400" height="220" fill="url(#bg)"/>
+  <!-- faint grid -->
+  <g stroke="#12303a" stroke-width="1" opacity="0.5">
+    <line x1="0" y1="55" x2="400" y2="55"/><line x1="0" y1="110" x2="400" y2="110"/><line x1="0" y1="165" x2="400" y2="165"/>
+  </g>
+  <!-- CRT screen with stacked + falling blocks -->
+  <g filter="url(#glow)">
+    <rect x="232" y="26" width="150" height="120" rx="6" fill="#020403" stroke="#0f2a24"/>
+    <!-- stacked blocks (bottom) -->
+    <g fill="#00ff9f">
+      <rect x="242" y="126" width="14" height="14"/><rect x="258" y="126" width="14" height="14"/>
+      <rect x="290" y="126" width="14" height="14"/><rect x="322" y="126" width="14" height="14"/>
+      <rect x="338" y="126" width="14" height="14"/><rect x="354" y="126" width="14" height="14"/>
+      <rect x="322" y="110" width="14" height="14"/><rect x="354" y="110" width="14" height="14"/>
+      <rect x="354" y="94"  width="14" height="14"/>
+    </g>
+    <!-- falling block -->
+    <rect x="298" y="52" width="16" height="16" fill="#00d9ff"/>
+  </g>
+  <!-- title -->
+  <text x="20" y="60" font-family="'JetBrains Mono',monospace" font-size="13" fill="#6b7280" letter-spacing="2">FROM ONE GATE</text>
+  <text x="20" y="98" font-family="Inter,Arial,sans-serif" font-size="30" font-weight="800" fill="url(#acc)">NAND to</text>
+  <text x="20" y="130" font-family="Inter,Arial,sans-serif" font-size="30" font-weight="800" fill="url(#acc)">TETRIS</text>
+  <!-- chain nand -> ... -> cpu -->
+  <g font-family="'JetBrains Mono',monospace" font-size="10" fill="#9ca3af">
+    <text x="20" y="168">NAND</text><text x="66" y="168">&#8594;</text>
+    <text x="82" y="168">ALU</text><text x="112" y="168">&#8594;</text>
+    <text x="128" y="168">CPU</text><text x="160" y="168">&#8594;</text>
+    <text x="176" y="168" fill="#00ff9f">PLAY</text>
+  </g>
+  <text x="20" y="196" font-family="'JetBrains Mono',monospace" font-size="10" fill="#00d9ff">Basys3 &middot; Artix-7 &middot; VGA + keyboard</text>
+</svg>

--- a/projects/hack-computer-basys3.html
+++ b/projects/hack-computer-basys3.html
@@ -1,0 +1,842 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NAND to Tetris on Silicon: Building a Computer on a Basys3 | Ajaya Dahal</title>
+    <meta name="description" content="Building the Nand2Tetris Hack computer for real — from a single NAND gate up to a 16-bit CPU, VGA and PS/2 I/O, synthesized onto a Digilent Basys3 (Artix-7) and playing a keyboard-controlled game on a monitor. Timing-closed at 100 MHz, verified in simulation, with the exact ROM running live in your browser.">
+    <meta name="keywords" content="Nand2Tetris, Hack computer, Basys3, Artix-7, FPGA, Verilog, VGA, PS/2 keyboard, CPU design, computer architecture, Coursera, block RAM, Vivado, ILA, tetris">
+    <meta name="author" content="Ajaya Dahal">
+    <link rel="icon" type="image/x-icon" href="../iconss/logo.svg">
+    <link rel="canonical" href="https://ajayadahal.github.io/projects/hack-computer-basys3.html">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="NAND to Tetris on Silicon: A Computer Built on a Basys3">
+    <meta property="og:description" content="From one NAND gate to a playable game on real FPGA silicon — the Nand2Tetris Hack computer synthesized onto a Basys3 with VGA + keyboard. The exact machine code runs live in your browser.">
+    <meta property="og:url" content="https://ajayadahal.github.io/projects/hack-computer-basys3.html">
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "name": "NAND to Tetris on Silicon: Building a Computer on a Basys3",
+        "author": { "@type": "Person", "name": "Ajaya Dahal" },
+        "description": "A ground-up build of the Nand2Tetris Hack computer in Verilog, synthesized onto a Digilent Basys3 FPGA with VGA and PS/2 I/O, running a keyboard-controlled game on a real monitor.",
+        "keywords": "Nand2Tetris, Hack computer, Basys3, FPGA, Verilog, VGA, PS/2, CPU design",
+        "proficiencyLevel": "Expert"
+    }
+    </script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <!-- Mermaid (diagrams), KaTeX (equations), Prism (code) -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-verilog.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-python.min.js"></script>
+    <style>
+        :root {
+            --bg-primary: #0a0e14; --bg-secondary: #151b24; --bg-tertiary: #1f2937;
+            --bg-card: #161d27; --text-primary: #e6e8eb; --text-secondary: #9ca3af;
+            --text-muted: #6b7280; --accent-1: #1976d2; --accent-2: #42a5f5;
+            --accent-cyan: #00d9ff; --accent-green: #00ff9f; --accent-amber: #ffb020; --accent-red: #ff5470;
+            --border-color: #2d3748;
+            --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            --font-mono: 'JetBrains Mono', monospace; --max-width: 1100px;
+        }
+        body { font-family: var(--font-sans); font-size: 16px; line-height: 1.7; color: var(--text-primary); background: var(--bg-primary); background-image: radial-gradient(circle at 20% 30%, rgba(25, 118, 210, 0.05) 0%, transparent 50%), radial-gradient(circle at 80% 70%, rgba(0, 217, 255, 0.04) 0%, transparent 50%); background-attachment: fixed; -webkit-font-smoothing: antialiased; }
+        a { color: var(--accent-cyan); text-decoration: none; transition: color 0.2s; } a:hover { color: var(--accent-green); }
+        .top-nav { position: fixed; top: 0; left: 0; right: 0; z-index: 100; background: rgba(10, 14, 20, 0.92); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border-color); padding: 14px 0; }
+        .top-nav .inner { max-width: var(--max-width); margin: 0 auto; padding: 0 24px; display: flex; justify-content: space-between; align-items: center; }
+        .top-nav .brand { font-weight: 700; font-size: 1.1rem; color: var(--text-primary); } .top-nav .brand span { color: var(--accent-cyan); }
+        .top-nav .links { display: flex; gap: 20px; font-size: 0.9rem; } .top-nav .links a { color: var(--text-secondary); font-weight: 500; } .top-nav .links a:hover { color: var(--accent-cyan); }
+        .hero { max-width: var(--max-width); margin: 0 auto; padding: 120px 24px 50px; }
+        .hero .breadcrumb { font-size: 0.85rem; color: var(--text-muted); margin-bottom: 24px; } .hero .breadcrumb a { color: var(--text-muted); } .hero .breadcrumb a:hover { color: var(--accent-cyan); }
+        .hero .badge-row { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 20px; }
+        .hero .badge-row .badge { background: rgba(0, 217, 255, 0.1); color: var(--accent-cyan); padding: 4px 14px; border-radius: 20px; font-size: 0.8rem; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; border: 1px solid rgba(0,217,255,0.2); }
+        .hero h1 { font-size: clamp(2.2rem, 5vw, 3.2rem); font-weight: 800; line-height: 1.12; background: linear-gradient(135deg, var(--accent-cyan) 0%, var(--accent-2) 60%, var(--accent-green) 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; margin-bottom: 16px; }
+        .hero .subtitle { font-size: 1.15rem; color: var(--text-secondary); line-height: 1.6; max-width: 780px; margin-bottom: 32px; }
+        .stat-bar { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 16px; margin-bottom: 36px; }
+        .stat-card { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 10px; padding: 18px; text-align: center; }
+        .stat-card .number { font-size: 1.35rem; font-weight: 800; font-family: var(--font-mono); background: linear-gradient(135deg, var(--accent-cyan), var(--accent-green)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+        .stat-card .label { font-size: 0.75rem; color: var(--text-muted); margin-top: 4px; font-weight: 500; }
+        .cta-row { display: flex; gap: 14px; flex-wrap: wrap; }
+        .btn { display: inline-flex; align-items: center; gap: 8px; padding: 12px 26px; border-radius: 8px; font-weight: 600; font-size: 0.95rem; transition: all 0.2s; border: none; cursor: pointer; text-decoration: none; }
+        .btn-primary { background: linear-gradient(135deg, var(--accent-1), var(--accent-cyan)); color: white; box-shadow: 0 4px 16px rgba(0, 217, 255, 0.25); } .btn-primary:hover { transform: translateY(-2px); color: white; }
+        .btn-outline { background: transparent; color: var(--text-primary); border: 1px solid var(--border-color); } .btn-outline:hover { border-color: var(--accent-cyan); color: var(--accent-cyan); }
+        .container { max-width: var(--max-width); margin: 0 auto; padding: 0 24px; }
+        section { padding: 56px 0; } section + section { border-top: 1px solid rgba(45, 55, 72, 0.5); }
+        .act-num { font-family: var(--font-mono); font-size: 0.8rem; color: var(--accent-cyan); letter-spacing: 3px; text-transform: uppercase; margin-bottom: 8px; }
+        .section-label { font-size: 0.75rem; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--accent-1); margin-bottom: 10px; }
+        .section-title { font-size: 1.9rem; font-weight: 700; margin-bottom: 14px; color: var(--text-primary); }
+        .section-desc, .prose p { font-size: 1rem; color: var(--text-secondary); max-width: 760px; margin-bottom: 18px; }
+        .prose strong { color: var(--text-primary); }
+        .prose .lead { font-size: 1.12rem; color: var(--text-primary); }
+        .pullquote { border-left: 3px solid var(--accent-cyan); padding: 14px 22px; margin: 26px 0; background: rgba(0,217,255,0.04); border-radius: 0 8px 8px 0; font-size: 1.1rem; color: var(--text-primary); font-style: italic; max-width: 780px; }
+        .mermaid { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 12px; padding: 22px; margin: 22px 0; text-align: center; overflow-x: auto; }
+        .figure { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 12px; padding: 14px; margin: 22px 0; }
+        .figure img { width: 100%; display: block; border-radius: 8px; }
+        .figure figcaption { color: var(--text-muted); font-size: 0.82rem; margin-top: 10px; text-align: center; }
+        .gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 14px; margin: 22px 0; }
+        .gallery figure { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 10px; padding: 8px; transition: border-color .2s, transform .2s; }
+        .gallery figure:hover { border-color: var(--accent-cyan); transform: translateY(-3px); }
+        .gallery img { width: 100%; border-radius: 6px; display: block; }
+        .gallery figcaption { text-align: center; color: var(--text-secondary); font-size: 0.8rem; margin-top: 6px; font-family: var(--font-mono); }
+        .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; } @media(max-width:820px){ .two-col{ grid-template-columns:1fr; } }
+        .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 18px; margin: 18px 0; }
+        .card { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 12px; padding: 24px; transition: border-color .2s; }
+        .card:hover { border-color: rgba(0,217,255,0.4); }
+        .card .card-icon { font-size: 1.5rem; margin-bottom: 10px; }
+        .card h3 { font-size: 1.08rem; font-weight: 700; margin-bottom: 8px; }
+        .card p { font-size: 0.9rem; color: var(--text-secondary); line-height: 1.6; }
+        .eq-box { background: var(--bg-secondary); border: 1px solid var(--border-color); border-left: 3px solid var(--accent-green); border-radius: 8px; padding: 16px 20px; margin: 16px 0; overflow-x: auto; }
+        .eq-box .cap { color: var(--text-muted); font-size: 0.82rem; margin-top: 8px; }
+        pre[class*="language-"] { border-radius: 10px; border: 1px solid var(--border-color); font-size: 0.82rem; margin: 16px 0; }
+        .code-cap { font-family: var(--font-mono); font-size: 0.75rem; color: var(--text-muted); margin: 16px 0 -8px; }
+        .svc-table { width: 100%; border-collapse: separate; border-spacing: 0; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 12px; overflow: hidden; margin: 18px 0; }
+        .svc-table th { text-align: left; padding: 13px 18px; font-size: 0.72rem; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-muted); background: var(--bg-tertiary); border-bottom: 1px solid var(--border-color); }
+        .svc-table td { padding: 13px 18px; font-size: 0.88rem; color: var(--text-secondary); border-bottom: 1px solid rgba(45, 55, 72, 0.3); vertical-align: top; }
+        .svc-table tr:last-child td { border-bottom: none; }
+        .svc-table code { font-family: var(--font-mono); font-size: 0.82rem; background: rgba(0, 217, 255, 0.08); color: var(--accent-cyan); padding: 2px 6px; border-radius: 4px; }
+        .card code, .section-desc code, .prose p code { font-family: var(--font-mono); font-size: 0.82rem; background: rgba(0, 217, 255, 0.08); color: var(--accent-cyan); padding: 1px 5px; border-radius: 4px; }
+        .pass-banner { background: #0d1b17; border: 1px solid var(--accent-green); border-radius: 10px; padding: 16px 20px; font-family: var(--font-mono); font-size: 0.85rem; color: var(--text-primary); white-space: pre; overflow-x: auto; margin: 20px 0; }
+        .pass-banner .ok { color: var(--accent-green); font-weight: 700; }
+        .callout { background: rgba(255,176,32,0.06); border: 1px solid rgba(255,176,32,0.3); border-radius: 10px; padding: 18px 22px; margin: 20px 0; }
+        .callout h4 { color: var(--accent-amber); font-size: 0.95rem; margin-bottom: 8px; }
+        .callout p { font-size: 0.9rem; color: var(--text-secondary); }
+        details.war { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 10px; margin: 12px 0; overflow: hidden; }
+        details.war summary { padding: 16px 20px; cursor: pointer; font-weight: 600; color: var(--text-primary); list-style: none; display: flex; align-items: center; gap: 10px; }
+        details.war summary::-webkit-details-marker { display: none; }
+        details.war summary::before { content: '▸'; color: var(--accent-cyan); transition: transform .2s; }
+        details.war[open] summary::before { transform: rotate(90deg); }
+        details.war .body { padding: 0 20px 18px; color: var(--text-secondary); font-size: 0.9rem; }
+        details.war .body code { font-family: var(--font-mono); font-size: 0.82rem; color: var(--accent-cyan); background: rgba(0,217,255,0.08); padding: 1px 5px; border-radius: 4px; }
+        .video-slot { position: relative; background: var(--bg-secondary); border: 1px dashed var(--border-color); border-radius: 12px; padding: 40px 24px; text-align: center; margin: 22px 0; }
+        .video-slot .soon { display:inline-block; background: rgba(0,217,255,0.1); color: var(--accent-cyan); border:1px solid rgba(0,217,255,0.3); border-radius: 20px; padding: 4px 14px; font-size: 0.78rem; font-weight: 600; letter-spacing: 1px; margin-bottom: 12px; }
+        .pubs { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 16px; margin: 20px 0; }
+        .pub-card { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 12px; padding: 20px; transition: border-color .2s, transform .2s; }
+        .pub-card:hover { border-color: var(--accent-cyan); transform: translateY(-3px); }
+        .pub-card .pub-title { font-weight: 700; color: var(--text-primary); font-size: 0.98rem; line-height: 1.4; margin-bottom: 8px; display: block; }
+        .pub-card .pub-authors { color: var(--text-secondary); font-size: 0.82rem; margin-bottom: 6px; }
+        .pub-card .pub-venue { color: var(--text-muted); font-size: 0.8rem; font-style: italic; }
+        .pub-card .pub-tags { margin-top: 10px; display: flex; gap: 6px; flex-wrap: wrap; }
+        .pub-card .pub-tags span { font-size: 0.68rem; background: rgba(0,217,255,0.08); color: var(--accent-cyan); padding: 2px 8px; border-radius: 10px; }
+        .pub-list { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 12px; padding: 8px 20px; margin-top: 16px; }
+        .pub-list .row { padding: 12px 0; border-bottom: 1px solid rgba(45,55,72,0.3); font-size: 0.9rem; }
+        .pub-list .row:last-child { border-bottom: none; }
+        .pub-list .row .yr { color: var(--text-muted); font-family: var(--font-mono); font-size: 0.8rem; }
+        .har-widget-shell { margin: 24px 0; }
+        .page-footer { padding: 40px 0; border-top: 1px solid var(--border-color); text-align: center; font-size: 0.85rem; color: var(--text-muted); }
+        .page-footer a { color: var(--text-secondary); } .page-footer a:hover { color: var(--accent-cyan); }
+        .disclaimer { color: var(--text-muted); font-size: 0.78rem; font-style: italic; margin-top: 8px; }
+        /* --- custom readable roadmap (replaces low-contrast mermaid timeline) --- */
+        .roadmap { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; margin: 28px 0; position: relative; }
+        .roadmap::before { content: ''; position: absolute; top: 10px; left: 8%; right: 8%; height: 2px; background: linear-gradient(90deg, var(--accent-1), var(--accent-cyan), var(--accent-amber), var(--accent-green)); opacity: 0.55; }
+        .roadmap-step { position: relative; }
+        .roadmap-dot { width: 22px; height: 22px; border-radius: 50%; background: var(--c, var(--accent-cyan)); box-shadow: 0 0 12px var(--c, var(--accent-cyan)); margin: 0 auto 16px; border: 3px solid var(--bg-primary); position: relative; z-index: 1; }
+        .roadmap-card { background: var(--bg-secondary); border: 1px solid var(--border-color); border-top: 3px solid var(--c, var(--accent-cyan)); border-radius: 10px; padding: 16px; height: 100%; }
+        .roadmap-card h4 { color: var(--text-primary); font-size: 1rem; margin-bottom: 10px; }
+        .roadmap-card .when { color: var(--c, var(--accent-cyan)); font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 1px; display: block; margin-bottom: 6px; }
+        .roadmap-card ul { list-style: none; padding: 0; margin: 0; }
+        .roadmap-card li { color: var(--text-secondary); font-size: 0.85rem; padding: 4px 0 4px 16px; position: relative; line-height: 1.5; }
+        .roadmap-card li::before { content: '▸'; color: var(--c, var(--accent-cyan)); position: absolute; left: 0; }
+        @media (max-width: 820px) { .roadmap { grid-template-columns: 1fr; } .roadmap::before { display: none; } }
+        /* --- click-to-zoom lightbox for diagrams & figures --- */
+        .zoomable { position: relative; cursor: zoom-in; }
+        .zoomable::after { content: '⤢ zoom'; position: absolute; top: 10px; right: 12px; font-size: 0.7rem; color: var(--text-secondary); background: rgba(10,14,20,0.82); border: 1px solid var(--border-color); border-radius: 6px; padding: 3px 9px; pointer-events: none; opacity: 0; transition: opacity 0.2s; z-index: 3; }
+        .zoomable:hover::after { opacity: 1; }
+        .zoom-overlay { position: fixed; inset: 0; background: rgba(5,9,13,0.97); z-index: 1000; display: none; }
+        .zoom-overlay.open { display: block; }
+        .zoom-stage { position: absolute; inset: 0; overflow: hidden; cursor: grab; touch-action: none; }
+        .zoom-stage.grabbing { cursor: grabbing; }
+        .zoom-content { position: absolute; top: 0; left: 0; transform-origin: 0 0; will-change: transform; }
+        .zoom-content svg, .zoom-content img { display: block; max-width: none !important; width: 100%; height: 100%; }
+        .zoom-toolbar { position: fixed; top: 16px; right: 16px; display: flex; gap: 8px; z-index: 1002; }
+        .zoom-toolbar button { background: var(--bg-secondary); border: 1px solid var(--border-color); color: var(--text-primary); min-width: 42px; height: 42px; padding: 0 10px; border-radius: 8px; font-size: 1.05rem; font-family: var(--font-mono); cursor: pointer; transition: 0.2s; }
+        .zoom-toolbar button:hover { border-color: var(--accent-cyan); color: var(--accent-cyan); }
+        .zoom-caption { position: fixed; bottom: 14px; left: 0; right: 0; text-align: center; color: var(--text-muted); font-size: 0.85rem; padding: 0 20px; pointer-events: none; z-index: 1001; }
+        @media (max-width: 768px) { .hero h1 { font-size: 2rem; } .cards, .pubs { grid-template-columns: 1fr; } .stat-bar { grid-template-columns: repeat(2, 1fr); } }
+        /* ---- project-specific ---- */
+        .vga-wrap { margin: 22px 0; }
+        .vga-stage { background: #05070a; border: 1px solid var(--border-color); border-radius: 14px; padding: 18px; box-shadow: inset 0 0 60px rgba(0,255,159,0.05); }
+        .vga-bezel { background: linear-gradient(145deg,#0b0f16,#05070a); border: 2px solid #10151d; border-radius: 10px; padding: 14px; position: relative; }
+        #hackScreen { width: 100%; image-rendering: pixelated; display: block; border-radius: 6px; background:#020403; outline: none; box-shadow: 0 0 22px rgba(0,255,159,0.12); }
+        .scanlines { position:absolute; inset:14px; border-radius:6px; pointer-events:none; background: repeating-linear-gradient(to bottom, rgba(0,0,0,0) 0px, rgba(0,0,0,0) 2px, rgba(0,0,0,0.16) 3px); mix-blend-mode: multiply; }
+        .vga-hud { display:flex; justify-content:space-between; align-items:center; margin-top:12px; font-family: var(--font-mono); font-size:0.78rem; color: var(--text-muted); flex-wrap:wrap; gap:10px; }
+        .vga-hud .dot { display:inline-block; width:8px; height:8px; border-radius:50%; background: var(--accent-green); margin-right:6px; box-shadow:0 0 8px var(--accent-green); animation: pulse 1.4s infinite; }
+        @keyframes pulse { 0%,100%{opacity:1;} 50%{opacity:0.35;} }
+        .emu-controls { display:flex; gap:10px; justify-content:center; margin-top:14px; flex-wrap:wrap; }
+        .key-btn { font-family: var(--font-mono); background: var(--bg-tertiary); color: var(--text-primary); border:1px solid var(--border-color); border-radius:8px; padding:12px 18px; font-size:1rem; cursor:pointer; user-select:none; transition: all .12s; min-width:52px; }
+        .key-btn:hover { border-color: var(--accent-cyan); color: var(--accent-cyan); }
+        .key-btn:active, .key-btn.down { background: var(--accent-cyan); color:#04121a; border-color: var(--accent-cyan); transform: translateY(1px); }
+        .emu-hint { text-align:center; color: var(--text-muted); font-size:0.82rem; margin-top:10px; }
+        .emu-hint b { color: var(--accent-cyan); }
+        .bitfield { width:100%; overflow-x:auto; margin:20px 0; }
+        .bitfield table { border-collapse:collapse; margin:0 auto; font-family:var(--font-mono); font-size:0.72rem; min-width:640px; }
+        .bitfield td { border:1px solid var(--border-color); padding:8px 6px; text-align:center; color:var(--text-secondary); background:var(--bg-secondary); }
+        .bitfield td.bit { color:var(--text-muted); font-size:0.62rem; border:none; background:transparent; padding:2px; }
+        .bitfield .grp-i { background: rgba(0,217,255,0.10); color: var(--accent-cyan); }
+        .bitfield .grp-c { background: rgba(0,255,159,0.08); color: var(--accent-green); }
+        .bitfield .grp-d { background: rgba(255,176,32,0.08); color: var(--accent-amber); }
+        .bitfield .grp-j { background: rgba(255,84,112,0.08); color: var(--accent-red); }
+        .ladder { display:flex; flex-direction:column; gap:6px; margin:20px 0; }
+        .rung { display:flex; align-items:center; gap:14px; background:var(--bg-secondary); border:1px solid var(--border-color); border-radius:10px; padding:12px 18px; }
+        .rung .lvl { font-family:var(--font-mono); font-size:0.72rem; color:var(--text-muted); width:38px; }
+        .rung .nm { font-weight:700; color:var(--text-primary); min-width:130px; }
+        .rung .ds { color:var(--text-secondary); font-size:0.86rem; }
+        .rung.hl { border-color: rgba(0,255,159,0.4); box-shadow: 0 0 0 1px rgba(0,255,159,0.15) inset; }
+        .rung.hl .nm { color: var(--accent-green); }
+        .status-pill { display:inline-flex; align-items:center; gap:6px; font-family:var(--font-mono); font-size:0.72rem; padding:3px 10px; border-radius:20px; border:1px solid; }
+        .status-pill.met { color:var(--accent-green); border-color:rgba(0,255,159,0.35); background:rgba(0,255,159,0.06); }
+    </style>
+</head>
+<body>
+
+<nav class="top-nav"><div class="inner"><a href="../home.html" class="brand"><span>A</span>jaya</a><div class="links"><a href="../home.html">Portfolio</a><a href="#ladder">The Build</a><a href="#play">Play It</a><a href="https://github.com/ajayadaha1/HackComputer" target="_blank">Repo</a></div></div></nav>
+
+<header class="hero">
+    <div class="breadcrumb"><a href="../home.html">Portfolio</a> &rarr; <a href="../home.html#page-3">Projects</a> &rarr; NAND to Tetris on a Basys3</div>
+    <div class="badge-row">
+        <span class="badge">Nand2Tetris</span>
+        <span class="badge">Basys3 / Artix-7</span>
+        <span class="badge">16-bit CPU</span>
+        <span class="badge">VGA</span>
+        <span class="badge">PS/2 Keyboard</span>
+        <span class="badge">Verilog</span>
+    </div>
+    <h1>NAND to Tetris, on Real Silicon</h1>
+    <p class="subtitle">
+        I wanted to understand a computer from the <strong>very bottom</strong> &mdash; not the API, not the
+        ISA, but the <em>gates</em>. So I took the <strong>Nand2Tetris</strong> course, and then did the thing the
+        course stops just short of: I built the whole <strong>Hack computer</strong> in Verilog, from a single
+        <strong>NAND</strong> up to a 16-bit CPU with <strong>VGA</strong> and a <strong>keyboard</strong>,
+        synthesized it onto a <strong>Digilent Basys3</strong>, and played a game on a real monitor.
+    </p>
+    <div class="stat-bar">
+        <div class="stat-card"><div class="number">1&rarr;&#8734;</div><div class="label">one NAND, whole computer</div></div>
+        <div class="stat-card"><div class="number">16-bit</div><div class="label">Hack CPU</div></div>
+        <div class="stat-card"><div class="number">100 MHz</div><div class="label">+1.74 ns slack (MET)</div></div>
+        <div class="stat-card"><div class="number">512&times;256</div><div class="label">VGA framebuffer</div></div>
+        <div class="stat-card"><div class="number">7</div><div class="label">testbenches, all green</div></div>
+    </div>
+    <div class="cta-row">
+        <a href="#play" class="btn btn-primary">&#9654; Play the game (in your browser)</a>
+        <a href="https://github.com/ajayadaha1/HackComputer" target="_blank" class="btn btn-outline">GitHub Repository</a>
+        <a href="https://www.coursera.org/learn/build-a-computer" target="_blank" class="btn btn-outline">The Course &rarr;</a>
+    </div>
+</header>
+
+<!-- ========================= ACT 1 — ORIGINS ========================= -->
+<section id="origins">
+    <div class="container prose">
+        <div class="act-num">Act 1 &mdash; The itch</div>
+        <div class="section-title">I wanted to see the bottom of the stack</div>
+        <p class="lead">
+            I spend my days as an FPGA engineer, high up the abstraction ladder &mdash; AXI, PetaLinux, AI Engines.
+            But a nagging question kept returning: if you keep asking <em>&ldquo;and what is that made of?&rdquo;</em>
+            all the way down, where do you land? What is the <strong>smallest true thing</strong> a computer is built from?
+        </p>
+        <p>
+            The answer, famously, is a single logic gate. That&rsquo;s the premise of
+            <a href="https://www.nand2tetris.org/" target="_blank">Nand2Tetris</a> &mdash; <em>&ldquo;The Elements of
+            Computing Systems&rdquo;</em> by Nisan and Schocken, which I took through
+            <a href="https://www.coursera.org/learn/build-a-computer" target="_blank">Coursera&rsquo;s
+            <em>Build a Modern Computer from First Principles</em></a>. You start with one primitive, the
+            <strong>NAND</strong> gate, and climb: from NAND you build every other gate, from gates an ALU, from the
+            ALU and some flip-flops a CPU, and from the CPU a whole machine that runs software you also write.
+        </p>
+        <div class="pullquote">
+            The course&rsquo;s promise is irresistible: nothing is a black box. Every layer is something you built out of
+            the layer below, and the only thing you took on faith is a single NAND gate.
+        </div>
+    </div>
+</section>
+
+<!-- ========================= ACT 2 — THE TWIST ========================= -->
+<section id="twist">
+    <div class="container prose">
+        <div class="act-num">Act 2 &mdash; The twist</div>
+        <div class="section-title">The course stops at an emulator. I had a Basys3 on my desk.</div>
+        <p>
+            Nand2Tetris is brilliant, but it lives in <strong>software</strong>: you draw your chips in a teaching HDL
+            and test them in a hardware <em>simulator</em>, and the final &ldquo;computer&rdquo; runs inside a CPU
+            emulator. It&rsquo;s the right pedagogy &mdash; but the machine never becomes a <em>machine</em>. There is no
+            clock you can probe, no pixel that is actually lit, no key that is actually pressed.
+        </p>
+        <p>
+            Sitting in a drawer was a <strong>Digilent Basys3</strong> &mdash; a Xilinx <strong>Artix-7
+            (xc7a35t)</strong> board with a VGA port and a USB host that speaks PS/2. So the project chose itself:
+            <strong>take the Hack computer off the emulator and put it on silicon.</strong> Re-write the chips in real
+            Verilog, make the memories real block RAM, give it a VGA controller for eyes and a keyboard decoder for
+            ears, close timing, generate a bitstream &mdash; and play a game on an actual monitor.
+        </p>
+        <div class="callout">
+            <h4>The one rule</h4>
+            <p>Stay honest to the spirit of Nand2Tetris: the datapath is still composed from the course&rsquo;s gate-level
+            chips (the ALU is literally muxes, adders and <code>Or8Way</code>), not a behavioral <code>a+b</code>. The FPGA
+            only gets behavioral help where physics demands it &mdash; the large memories, which <em>must</em> be block RAM.</p>
+        </div>
+    </div>
+</section>
+
+<!-- ========================= ACT 3 — THE LADDER ========================= -->
+<section id="ladder">
+    <div class="container prose">
+        <div class="act-num">Act 3 &mdash; The ladder</div>
+        <div class="section-title">From one gate to a whole computer</div>
+        <p>
+            The Hack architecture is a clean climb. Each rung is built <em>only</em> from the rungs beneath it &mdash;
+            this is the whole point. The repo I started from had the lower rungs (the combinational and sequential
+            chips), but the top of the ladder &mdash; the parts that make it a <em>computer</em> &mdash; was missing:
+            <code>PC.v</code> was empty, <code>Inc16.v</code> was a stub, and there was no CPU, memory, ROM, or top level at all.
+        </p>
+        <div class="ladder">
+            <div class="rung"><span class="lvl">L0</span><span class="nm">NAND</span><span class="ds">the single primitive &mdash; the one thing taken on faith</span></div>
+            <div class="rung"><span class="lvl">L1</span><span class="nm">Gates</span><span class="ds">Not, And, Or, Xor, Mux, DMux &mdash; all from NAND</span></div>
+            <div class="rung"><span class="lvl">L2</span><span class="nm">16-bit &amp; multi-way</span><span class="ds">Not16, And16, Mux16, Mux4Way16, Or8Way, DMux8Way</span></div>
+            <div class="rung"><span class="lvl">L3</span><span class="nm">Arithmetic</span><span class="ds">HalfAdder &rarr; FullAdder &rarr; Add16 &rarr; Inc16 &rarr; <strong>ALU</strong></span></div>
+            <div class="rung"><span class="lvl">L4</span><span class="nm">Memory</span><span class="ds">DFF &rarr; Bit &rarr; Register &rarr; RAM8 &rarr; RAM64 &rarr; &hellip; &rarr; RAM16K</span></div>
+            <div class="rung hl"><span class="lvl">L5</span><span class="nm">CPU + PC</span><span class="ds">A/D registers, the ALU, jump logic, program counter &mdash; <em>built here</em></span></div>
+            <div class="rung hl"><span class="lvl">L6</span><span class="nm">Computer</span><span class="ds">CPU + instruction ROM + data Memory with mapped I/O &mdash; <em>built here</em></span></div>
+            <div class="rung hl"><span class="lvl">L7</span><span class="nm">Basys3 top</span><span class="ds">clocking, VGA, PS/2, constraints, bitstream &mdash; <em>the FPGA layer</em></span></div>
+        </div>
+        <p>
+            The ALU is a good sanity check that this is the real thing and not a shortcut: it computes its 18 functions
+            by zeroing/negating its inputs, choosing between <code>x&amp;y</code> and <code>x+y</code>, and optionally
+            negating the output &mdash; all wired from the course&rsquo;s own <code>Mux16</code>, <code>Add16</code> and
+            <code>Or8Way</code> chips. Before touching the FPGA I completed and fixed the ladder, including two latent
+            gate bugs (<code>DMux</code> and <code>Or16</code> had swapped primitive terminals), then proved the new
+            rungs in simulation.
+        </p>
+    </div>
+</section>
+
+<!-- ========================= ACT 4 — EMULATOR TO SILICON ========================= -->
+<section id="silicon">
+    <div class="container prose">
+        <div class="act-num">Act 4 &mdash; Emulator &rarr; silicon</div>
+        <div class="section-title">Where the abstraction meets physics</div>
+        <p>
+            In the Nand2Tetris emulator, memory is <strong>combinational</strong>: you put an address on <code>A</code>
+            and the value at <code>RAM[A]</code> is <em>instantly</em> there in the same cycle. That is a lie the
+            emulator tells you for free. On an Artix-7, the only way to fit 32K&times;16 of ROM plus 16K of RAM plus an
+            8K framebuffer is <strong>block RAM</strong> &mdash; and block RAM is <em>synchronous</em>: you present an
+            address on one clock edge and the data arrives on the <em>next</em>.
+        </p>
+        <p>
+            That one-cycle read latency is exactly the kind of detail the emulator hides and hardware won&rsquo;t. The
+            fix is a small, clean idea: run <strong>everything on one 100 MHz clock</strong>, but only let the CPU
+            <em>step</em> once every 16 clocks via a clock-enable (<code>cpu_en</code>). The block RAMs are read
+            <em>every</em> clock, so between two CPU steps the <code>pc</code>/<code>address</code> lines have been
+            stable for many cycles and the read data is long since valid. The latency is real &mdash; it&rsquo;s just
+            fully hidden in the gap between steps. No gated clocks, no negedge tricks, clean single-edge inference.
+        </p>
+        <div class="mermaid">
+flowchart LR
+    OSC["100 MHz<br/>oscillator (W5)"] --> DIV["clock-enable<br/>divider"]
+    DIV -->|pix_en 25 MHz| VGA["VGA controller"]
+    DIV -->|cpu_en ~6 MHz| CPU["Hack CPU"]
+    CPU -->|pc| ROM["Instruction ROM<br/>(block RAM)"]
+    ROM -->|instruction| CPU
+    CPU -->|addressM / outM / writeM| MEM["Data Memory<br/>(block RAM)"]
+    MEM -->|inM| CPU
+    MEM --- SCR["Screen buffer<br/>512x256 (dual-port)"]
+    SCR -->|pixels| VGA
+    KBD["PS/2 keyboard<br/>decoder"] -->|key code| MEM
+    VGA -->|RGB + sync| MON["VGA monitor"]
+    style CPU fill:#0d2438,stroke:#00d9ff,color:#e6e8eb
+    style ROM fill:#12261c,stroke:#00ff9f,color:#e6e8eb
+    style MEM fill:#12261c,stroke:#00ff9f,color:#e6e8eb
+    style SCR fill:#12261c,stroke:#00ff9f,color:#e6e8eb
+        </div>
+        <p>
+            The CPU&rsquo;s registers only latch on <code>cpu_en</code>, so the long combinational path
+            (instruction&nbsp;&rarr;&nbsp;decode&nbsp;&rarr;&nbsp;ripple-carry&nbsp;ALU&nbsp;&rarr;&nbsp;next&nbsp;PC) is
+            genuinely a <strong>multicycle path</strong> &mdash; a fact I had to <em>tell</em> the timing engine before
+            it would close (see the war-stories). The result meets timing at 100 MHz with room to spare.
+        </p>
+
+        <div class="section-title" style="font-size:1.35rem; margin-top:40px;">The memory map</div>
+        <p>The CPU sees one 15-bit data address space; three regions live inside it. The screen and keyboard are just
+        <em>memory</em> &mdash; write a word to <code>16384</code> and 16 pixels light up; read <code>24576</code> and
+        you get whatever key is held.</p>
+        <table class="svc-table">
+            <thead><tr><th>Address</th><th>Region</th><th>Size</th><th>Meaning</th></tr></thead>
+            <tbody>
+                <tr><td><code>0x0000&ndash;0x3FFF</code></td><td>Data RAM</td><td>16K words</td><td>general read/write memory &amp; variables</td></tr>
+                <tr><td><code>0x4000&ndash;0x5FFF</code></td><td>Screen</td><td>8K words</td><td>512&times;256 monochrome framebuffer (16 px / word)</td></tr>
+                <tr><td><code>0x6000</code></td><td>Keyboard</td><td>1 word</td><td>current key code (0 = none), read-only</td></tr>
+            </tbody>
+        </table>
+
+        <div class="section-title" style="font-size:1.35rem; margin-top:40px;">One instruction, sixteen bits</div>
+        <p>The whole ISA is two instruction types. If the top bit is 0 it&rsquo;s an <strong>A-instruction</strong> (load
+        a 15-bit constant into <code>A</code>). If it&rsquo;s 1 it&rsquo;s a <strong>C-instruction</strong>, packed like this:</p>
+        <div class="bitfield">
+        <table>
+            <tr>
+                <td class="bit">15</td><td class="bit">14</td><td class="bit">13</td><td class="bit">12</td>
+                <td class="bit">11</td><td class="bit">10</td><td class="bit">9</td><td class="bit">8</td><td class="bit">7</td><td class="bit">6</td>
+                <td class="bit">5</td><td class="bit">4</td><td class="bit">3</td>
+                <td class="bit">2</td><td class="bit">1</td><td class="bit">0</td>
+            </tr>
+            <tr>
+                <td class="grp-i">1</td><td class="grp-i">1</td><td class="grp-i">1</td>
+                <td class="grp-c">a</td>
+                <td class="grp-c">c1</td><td class="grp-c">c2</td><td class="grp-c">c3</td><td class="grp-c">c4</td><td class="grp-c">c5</td><td class="grp-c">c6</td>
+                <td class="grp-d">d1</td><td class="grp-d">d2</td><td class="grp-d">d3</td>
+                <td class="grp-j">j1</td><td class="grp-j">j2</td><td class="grp-j">j3</td>
+            </tr>
+            <tr>
+                <td class="grp-i" colspan="3">op = C</td>
+                <td class="grp-c" colspan="7">comp (A or M as y; zx nx zy ny f no)</td>
+                <td class="grp-d" colspan="3">dest A/D/M</td>
+                <td class="grp-j" colspan="3">jump &lt; = &gt;</td>
+            </tr>
+        </table>
+        </div>
+        <p>That is the entire decode job of the CPU: split those fields, feed <code>comp</code> to the ALU, route the
+        result to the chosen destinations, and load the program counter with <code>A</code> when the jump condition matches.</p>
+    </div>
+</section>
+
+<!-- ========================= ACT 5 — EYES AND EARS ========================= -->
+<section id="io">
+    <div class="container prose">
+        <div class="act-num">Act 5 &mdash; Eyes and ears</div>
+        <div class="section-title">Giving the machine a monitor and a keyboard</div>
+        <p>
+            A computer you can&rsquo;t see or touch isn&rsquo;t much fun. Two peripherals turn the Hack core into
+            something you can actually play with.
+        </p>
+        <div class="cards">
+            <div class="card">
+                <div class="card-icon">&#128421;&#65039;</div>
+                <h3>VGA &mdash; the eyes</h3>
+                <p>A 640&times;480 @ 60 Hz controller (25 MHz pixel clock via <code>pix_en</code>) paints the 512&times;256
+                Hack framebuffer into the top-left of the frame. The screen buffer is a <strong>true dual-port</strong>
+                block RAM: the CPU writes it as memory while the VGA scans it out as pixels &mdash; no arbitration,
+                no tearing. Horizontal/vertical timing was verified to the exact tick (period 800/96, 525&times;800).</p>
+            </div>
+            <div class="card">
+                <div class="card-icon">&#9000;&#65039;</div>
+                <h3>PS/2 &mdash; the ears</h3>
+                <p>The Basys3 USB host presents a keyboard as a PS/2 device. A receiver samples the 11-bit frames on the
+                falling edge of <code>PS2Clk</code>, tracks the <code>E0</code>/<code>F0</code> extended &amp; release
+                prefixes, and translates Set-2 scancodes into the Nand2Tetris key codes &mdash; letters, digits, and the
+                arrow keys (130&ndash;133) the game needs.</p>
+            </div>
+        </div>
+        <p>
+            The CPU itself stays faithful to the course design &mdash; A and D registers, the composed ALU, jump logic,
+            and the program counter &mdash; with one addition for the FPGA: a step-enable so a single fast clock can
+            drive the block RAMs while the CPU advances slowly.
+        </p>
+        <p class="code-cap">CPU.v &mdash; instruction decode and the ALU, wired from the course chips</p>
+<pre><code class="language-verilog">wire isC =  instruction[15];   // 1 =&gt; C-instruction
+wire isA = ~instruction[15];   // 1 =&gt; A-instruction
+
+// A register: A-instruction value, else ALU result
+Mux16 muxA(.a(instruction), .b(aluOut), .s(isC), .out(aRegIn));
+wire loadA = isA | (isC &amp; instruction[5]);           // dest A
+Register aRegister(.in(aRegIn), .load(loadA &amp; en), .clk(clk), .out(aReg));
+
+// ALU y input: A register or M (inM), chosen by the a-bit
+Mux16 muxY(.a(aReg), .b(inM), .s(instruction[12]), .out(aluY));
+
+ALU alu(.x(dReg), .y(aluY),
+        .zx(instruction[11]), .nx(instruction[10]),
+        .zy(instruction[9]),  .ny(instruction[8]),
+        .f(instruction[7]),   .no(instruction[6]),
+        .out(aluOut), .zr(zr), .ng(ng));
+
+assign writeM = isC &amp; instruction[3];                // dest M
+wire pos = ~ng &amp; ~zr;
+wire doJump = isC &amp; ((instruction[2] &amp; ng) | (instruction[1] &amp; zr) | (instruction[0] &amp; pos));
+PC pc0(.in(aReg), .load(doJump &amp; en), .inc(en), .reset(reset), .clk(clk), .out(pcOut));</code></pre>
+
+        <div class="section-title" style="font-size:1.35rem; margin-top:40px;">Proving it, rung by rung</div>
+        <p>Nothing went to the board on faith. Every layer has a self-checking Verilog testbench, run in Vivado&rsquo;s
+        <code>xsim</code> &mdash; from single chips up to the full machine executing real programs and the game logic:</p>
+        <div class="pass-banner">tb_core     Inc16 / PC .................... <span class="ok">ALL PASS</span>
+tb_cpu      Add (2+3=5), Sum(1..10)=55 .... <span class="ok">ALL PASS</span>
+tb_computer memory-mapped screen + kbd .... <span class="ok">ALL PASS</span>
+tb_vga      640x480 timing (800/96 h, 525 v) <span class="ok">ALL PASS</span>
+tb_ps2/top  PS/2 key -&gt; CPU -&gt; screen ...... <span class="ok">ALL PASS</span>
+tb_game     block draws &amp; moves on VGA ..... <span class="ok">ALL PASS</span>
+tb_tetris   falls, locks, stacks, respawns . <span class="ok">ALL PASS</span></div>
+    </div>
+</section>
+
+<!-- ========================= ACT 6 — WAR STORIES ========================= -->
+<section id="warstories">
+    <div class="container prose">
+        <div class="act-num">Act 6 &mdash; The bugs worth remembering</div>
+        <div class="section-title">Where &ldquo;works in the emulator&rdquo; met the real board</div>
+        <p>The distance between a passing simulation and a working monitor was, as always, where the actual engineering
+        happened. Three that cost real time:</p>
+
+        <details class="war">
+            <summary>The ripple-carry ALU wouldn&rsquo;t close timing &mdash; until I told the truth about the clock</summary>
+            <div class="body">First implementation: <code>WNS = -0.673 ns</code>. The critical path was
+            <code>ROM &rarr; instruction decode &rarr; the 16-bit ripple-carry Add16 &rarr; the PC register</code> &mdash;
+            far too long for a 10 ns period. But it doesn&rsquo;t <em>need</em> to fit in 10 ns: the CPU only steps once
+            every 16 clocks, so that path has ~15 clocks to settle and is only ever captured on a <code>cpu_en</code> tick.
+            The static-timing engine didn&rsquo;t know that. A <code>set_multicycle_path</code> exception on the paths into
+            the CPU registers and the memory block RAMs turned the same physical design from <code>-0.673 ns</code> into
+            <code>+1.74 ns</code> of positive slack. The lesson is pure computer architecture: a slow, enable-gated core
+            on a fast clock is a multicycle design, and you have to say so.</div>
+        </details>
+
+        <details class="war">
+            <summary>The keyboard read &ldquo;E0&rdquo; as &ldquo;70&rdquo; &mdash; a reset that outlasted my patience</summary>
+            <div class="body">In the top-level testbench the arrow keys decoded to garbage: the first byte of every
+            keypress, <code>0xE0</code>, came out as <code>0x70</code> &mdash; <em>the exact same bits, shifted right by
+            one</em>. The bare PS/2 decoder passed in isolation, so the module was fine. The culprit was timing: the
+            board&rsquo;s power-on reset counts down over <strong>255 clocks</strong>, but my testbench only waited
+            <strong>40</strong> before it started clocking in the frame. The keyboard was still held in reset when the
+            start bit arrived, so it missed one falling edge and every subsequent bit landed one position off. A one-line
+            fix (wait for POR to finish) &mdash; but a perfect reminder that on real hardware, reset is not instantaneous
+            and off-by-one in <em>time</em> looks exactly like off-by-one in <em>data</em>.</div>
+        </details>
+
+        <details class="war">
+            <summary>Adding an ILA fought back three different ways</summary>
+            <div class="body">I wanted an Integrated Logic Analyzer on <code>pc</code>, <code>instruction</code>,
+            <code>outM</code> and the keyboard so I could watch the CPU on real silicon. Three separate battles: (1)
+            Vivado 2025.2 rejected the property <code>C_CLK_INPUT_FREQ_HZ</code> on the ILA core, which aborted insertion
+            half-way and left a broken hub; (2) inserting the debug core <em>after</em> <code>opt_design</code> pruned my
+            <code>mark_debug</code> taps (nothing was driving them yet) &rarr; &ldquo;driverless nets&rdquo; at placement;
+            (3) the auto-created <code>dbg_hub</code> came up with an unconnected clock. The clean resolution was to insert
+            the ILA <em>before</em> <code>opt_design</code> so the taps keep a load and the hub is generated with a proper
+            clock, and to extend the same multicycle exception to the ILA&rsquo;s capture registers. Both a plain and an
+            ILA-instrumented bitstream now build and meet timing.</div>
+        </details>
+
+        <div class="section-title" style="font-size:1.35rem; margin-top:40px;">What it costs on the Artix-7</div>
+        <p>The whole computer &mdash; CPU, ROM, RAM, framebuffer, VGA, keyboard &mdash; barely dents the little
+        <code>xc7a35t</code>. It is almost all memory; the logic is a rounding error.</p>
+        <table class="svc-table">
+            <thead><tr><th>Resource</th><th>Used</th><th>Of device</th><th>Note</th></tr></thead>
+            <tbody>
+                <tr><td>Slice LUTs</td><td>274</td><td>1.3 %</td><td>the entire CPU + I/O logic</td></tr>
+                <tr><td>Slice registers</td><td>135</td><td>0.3 %</td><td>A / D / PC + pipeline</td></tr>
+                <tr><td>Block RAM tiles</td><td>28.5</td><td>57 %</td><td>32K ROM + 16K RAM + 8K screen</td></tr>
+                <tr><td>Bonded IOB</td><td>34</td><td>32 %</td><td>VGA(14) + PS/2(2) + clk/btn + 16 LEDs</td></tr>
+                <tr><td>Timing</td><td colspan="2"><span class="status-pill met">&#9679; WNS +1.74 ns @ 100 MHz</span></td><td>all constraints met</td></tr>
+            </tbody>
+        </table>
+    </div>
+</section>
+
+<!-- ========================= ACT 7 — PLAY IT ========================= -->
+<section id="play">
+    <div class="container prose">
+        <div class="act-num">Act 7 &mdash; Play it</div>
+        <div class="section-title">A game, in machine code I wrote, on a computer I built</div>
+        <p>
+            The payoff. A falling-blocks game: a 16&times;16 block drops one row per tick, you steer it left/right, it
+            locks at the bottom and stacks, a new one spawns, and the board resets when the stack tops out. On the board
+            it runs on the real CPU, drawn over VGA, driven by the keyboard. To write it I also built a small
+            <strong>Hack assembler</strong> (in Python) that turns readable assembly into the 16-bit machine code the ROM
+            boots from.
+        </p>
+
+        <div class="callout">
+            <h4>&#9654; This is not a re-implementation &mdash; it&rsquo;s the real thing</h4>
+            <p>The screen below is a faithful <strong>Hack CPU emulator</strong> running in your browser, executing the
+            <em>exact same 258-word ROM</em> (<code>tetris.hex</code>) that is programmed onto the Basys3. Same bits, same
+            fetch/decode/execute, same framebuffer scanned to pixels. Click the screen and use the <b>arrow keys</b> (or
+            the buttons). What you see here is what lights up on the monitor.</p>
+        </div>
+
+        <div class="vga-wrap">
+            <div class="vga-stage">
+                <div class="vga-bezel">
+                    <canvas id="hackScreen" width="512" height="256" tabindex="0" aria-label="Hack computer VGA screen running the falling-blocks game"></canvas>
+                    <div class="scanlines"></div>
+                </div>
+                <div class="vga-hud">
+                    <span><span class="dot"></span>HACK CPU &middot; <span id="emuIps">booting&hellip;</span></span>
+                    <span>ROM: tetris.hex &middot; 258 words &middot; PC <span id="emuPc">0</span></span>
+                </div>
+            </div>
+            <div class="emu-controls">
+                <button class="key-btn" id="btnLeft" aria-label="left">&#9664;</button>
+                <button class="key-btn" id="btnDown" aria-label="down">&#9660;</button>
+                <button class="key-btn" id="btnRight" aria-label="right">&#9654;</button>
+                <button class="key-btn" id="btnReset" style="min-width:auto;">reset</button>
+                <button class="key-btn" id="btnPause" style="min-width:auto;">pause</button>
+            </div>
+            <div class="emu-hint">Click the screen, then steer with the <b>&larr; &rarr;</b> arrow keys. On the Basys3 the very same ROM runs the very same way &mdash; just on real gates, over a real VGA cable.</div>
+        </div>
+
+        <p class="code-cap">tetris.asm &mdash; the tick loop, in Hack assembly (assembled by tools/asm.py)</p>
+<pre><code class="language-plaintext">(FALLNOW)
+    @bx
+    D=M
+    @100
+    A=D+A          // &amp;height[bx]
+    D=M            // D = height[bx]
+    @15
+    D=A-D          // landing row = 15 - height[bx]
+    @landing
+    M=D
+    @by
+    D=M
+    @landing
+    D=M-D          // landing - by
+    @LAND
+    D;JLE          // by &gt;= landing  -&gt; lock the block
+    @DO_DOWN       // else fall one row: erase, by++, base += 512, redraw
+    D=A
+    @after_move
+    M=D
+    @CALL_ERASE
+    0;JMP</code></pre>
+        <p>
+            That <code>@100 &nbsp; A=D+A</code> is the whole trick to an array on a machine with no indexed addressing:
+            <code>height[]</code> lives at RAM word 100, and the column index is just added to the base to form the
+            pointer. The block&rsquo;s screen address is maintained the same way &mdash; falling one row is
+            <code>base += 512</code> because a 16-pixel-tall block spans 16 screen rows of 32 words each.
+        </p>
+    </div>
+</section>
+
+<!-- ========================= TECH STACK ========================= -->
+<section id="stack">
+    <div class="container">
+        <div class="section-label">Stack</div>
+        <div class="section-title">Technology &amp; Tools</div>
+        <table class="svc-table">
+            <thead><tr><th>Layer</th><th>Technology</th><th>Role</th></tr></thead>
+            <tbody>
+                <tr><td>Course / method</td><td><code>Nand2Tetris</code></td><td>NAND-up architecture &amp; the Hack ISA</td></tr>
+                <tr><td>Board</td><td><code>Digilent Basys3 (xc7a35t)</code></td><td>Artix-7 FPGA, VGA port, USB-HID host</td></tr>
+                <tr><td>RTL</td><td><code>Verilog</code></td><td>gate-level chips + CPU/Memory/Computer + I/O</td></tr>
+                <tr><td>Display</td><td><code>VGA 640x480@60</code></td><td>25 MHz pixel pipe, 512x256 framebuffer</td></tr>
+                <tr><td>Input</td><td><code>PS/2 (USB-HID)</code></td><td>Set-2 scancode &rarr; Hack key codes</td></tr>
+                <tr><td>Tools</td><td><code>Vivado 2025.2 + xsim</code></td><td>synth / impl / bitstream / simulation</td></tr>
+                <tr><td>Debug</td><td><code>Integrated Logic Analyzer</code></td><td>live capture of pc / instruction / outM</td></tr>
+                <tr><td>Toolchain</td><td><code>tools/asm.py (Python)</code></td><td>Hack assembler: .asm &rarr; ROM hex</td></tr>
+            </tbody>
+        </table>
+    </div>
+</section>
+
+<!-- ========================= BUILD IT YOURSELF ========================= -->
+<section id="build">
+    <div class="container prose">
+        <div class="section-label">Reproduce</div>
+        <div class="section-title">Build it yourself</div>
+        <p>Everything &mdash; RTL, testbenches, the assembler, the game, the build/program scripts and prebuilt
+        bitstreams &mdash; is in the repository. From a fresh clone:</p>
+        <p class="code-cap">assemble a program, simulate, then build &amp; flash the Basys3</p>
+<pre><code class="language-python"># 1. write &amp; assemble a program to a ROM image
+python3 tools/asm.py sim/games/tetris.asm -o sim/games/tetris.hex
+
+# 2. simulate the whole computer (Vivado xsim)
+bash build/run_sim.sh tb_tetris  sim/tb_tetris.v Computer.v CPU.v ...
+
+# 3. synthesize, close timing, generate the bitstream (arg2: 1=insert ILA)
+vivado -mode batch -source build/build.tcl -tclargs sim/games/tetris.hex 0
+
+# 4. program the board over JTAG, then plug in a VGA monitor + USB keyboard
+vivado -mode batch -source build/program.tcl</code></pre>
+        <p>The instruction ROM is the full 32K Hack address space, so a larger high-level game (compiled through the
+        Nand2Tetris Jack&nbsp;&rarr;&nbsp;VM&nbsp;&rarr;&nbsp;asm toolchain into a bigger <code>.hack</code>) drops
+        straight into the same ROM slot &mdash; the hardware doesn&rsquo;t change.</p>
+    </div>
+</section>
+
+<!-- ========================= RELATED ========================= -->
+<section id="related">
+    <div class="container" style="text-align:center;">
+        <div class="section-title">Related Projects</div>
+        <div class="cta-row" style="justify-content:center; margin-top:20px;">
+            <a href="wifi-har-versal.html" class="btn btn-outline">WiFi HAR on Versal AI Engine &rarr;</a>
+            <a href="cummings-fifo.html" class="btn btn-outline">Async FIFO (CDC) &rarr;</a>
+            <a href="72ns-gateway.html" class="btn btn-outline">72ns Gateway HFT &rarr;</a>
+        </div>
+    </div>
+</section>
+
+<footer class="page-footer"><div class="container">
+    <p><a href="../home.html">&larr; Portfolio</a> &nbsp;&middot;&nbsp; <a href="https://github.com/ajayadaha1/HackComputer" target="_blank">GitHub Repo</a> &nbsp;&middot;&nbsp; <a href="https://www.nand2tetris.org/" target="_blank">Nand2Tetris</a> &nbsp;&middot;&nbsp; <a href="https://www.coursera.org/learn/build-a-computer" target="_blank">Coursera</a> &nbsp;&middot;&nbsp; <a href="https://www.linkedin.com/in/ajaya-dahal-137b94108/" target="_blank">LinkedIn</a></p>
+    <p style="margin-top:10px; font-size:0.8rem;">Ajaya Dahal &middot; Sr. FPGA &amp; Network System Engineer &middot; Austin, TX</p>
+</div></footer>
+
+<script>
+    mermaid.initialize({
+        startOnLoad: true,
+        theme: 'dark',
+        themeVariables: {
+            darkMode: true, background: '#0a0e14',
+            primaryColor: '#0d2438', primaryTextColor: '#e6e8eb', primaryBorderColor: '#00d9ff',
+            lineColor: '#00ff9f', secondaryColor: '#1f2937', tertiaryColor: '#2d3748',
+            fontSize: '13px', fontFamily: 'JetBrains Mono, monospace'
+        }
+    });
+    window.addEventListener('DOMContentLoaded', function () {
+        if (window.renderMathInElement) {
+            renderMathInElement(document.body, {
+                delimiters: [ { left: '$$', right: '$$', display: true }, { left: '$', right: '$', display: false } ],
+                throwOnError: false
+            });
+        }
+    });
+</script>
+
+<!-- ===== A real Hack CPU, in JavaScript, running the exact tetris.hex ROM ===== -->
+<script>
+(function () {
+    // The actual 258-word instruction ROM assembled from sim/games/tetris.asm.
+    const ROM = [
+        0x4000,0xEC10,0x0010,0xE308,0x2000,0xEC10,0x0011,0xE308,0x0010,0xFC20,0xEA88,0x0010,
+        0xFDC8,0x0011,0xFC98,0x0008,0xE301,0x0064,0xEC10,0x0010,0xE308,0x0020,0xEC10,0x0011,
+        0xE308,0x0010,0xFC20,0xEA88,0x0010,0xFDC8,0x0011,0xFC98,0x0019,0xE301,0x0074,0xFC10,
+        0x0010,0xE4D0,0x002A,0xE304,0x0000,0xEA87,0x0010,0xEC10,0x0012,0xE308,0x0000,0xEC10,
+        0x0013,0xE308,0x4000,0xEC10,0x0010,0xE090,0x0014,0xE308,0x00C6,0xEC10,0x0015,0xE308,
+        0x00DD,0xEA87,0x6000,0xFC10,0x0016,0xE308,0x0016,0xFC10,0x0082,0xE4D0,0x0063,0xE305,
+        0x0012,0xFC10,0x0086,0xE302,0x0012,0xFC10,0x0001,0xE4D0,0x0017,0xE308,0x0017,0xFC10,
+        0x0064,0xE0A0,0xFC10,0x000F,0xE1D0,0x0013,0xF4D0,0x0086,0xE304,0x00AC,0xEC10,0x0015,
+        0xE308,0x00D0,0xEA87,0x0016,0xFC10,0x0084,0xE4D0,0x0086,0xE305,0x0012,0xFC10,0x001F,
+        0xE4D0,0x0086,0xE302,0x0012,0xFC10,0x0001,0xE090,0x0017,0xE308,0x0017,0xFC10,0x0064,
+        0xE0A0,0xFC10,0x000F,0xE1D0,0x0013,0xF4D0,0x0086,0xE304,0x00B2,0xEC10,0x0015,0xE308,
+        0x00D0,0xEA87,0x0012,0xFC10,0x0064,0xE0A0,0xFC10,0x000F,0xE1D0,0x0018,0xE308,0x0013,
+        0xFC10,0x0018,0xF1D0,0x009B,0xE306,0x00B8,0xEC10,0x0015,0xE308,0x00D0,0xEA87,0x0013,
+        0xFC10,0x00A1,0xE301,0x0000,0xEA87,0x0012,0xFC10,0x0064,0xE090,0x0019,0xE308,0x0019,
+        0xFC20,0xFDC8,0x0022,0xEA87,0x0012,0xFC88,0x0014,0xFC88,0x00C0,0xEA87,0x0012,0xFDC8,
+        0x0014,0xFDC8,0x00C0,0xEA87,0x0013,0xFDC8,0x0200,0xEC10,0x0014,0xF088,0x00C0,0xEA87,
+        0x00C6,0xEC10,0x0015,0xE308,0x00DD,0xEA87,0x1F40,0xEC10,0x001A,0xE308,0x001A,0xFC98,
+        0x00CA,0xE301,0x003E,0xEA87,0x0000,0xEC10,0x001B,0xE308,0x00DA,0xEC10,0x001C,0xE308,
+        0x00EA,0xEA87,0x0015,0xFC20,0xEA87,0x0001,0xECD0,0x001B,0xE308,0x00E7,0xEC10,0x001C,
+        0xE308,0x00EA,0xEA87,0x0015,0xFC20,0xEA87,0x0014,0xFC10,0x001D,0xE308,0x0010,0xEC10,
+        0x001E,0xE308,0x001B,0xFC10,0x001D,0xFC20,0xE308,0x0020,0xEC10,0x001D,0xF088,0x001E,
+        0xFC98,0x00F2,0xE301,0x001C,0xFC20,0xEA87
+    ];
+
+    const SCREEN = 16384, KBD = 24576, MASK = 0xFFFF;
+    let RAM, A, D, PC, key = 0, running = true, insThisSec = 0, lastSec = performance.now();
+
+    function reset() {
+        RAM = new Int32Array(24577);   // 0..16383 data, 16384..24575 screen, 24576 keyboard
+        A = 0; D = 0; PC = 0; key = 0;
+    }
+    reset();
+
+    // ALU: c = 6 control bits [zx nx zy ny f no]
+    function alu(x, y, c) {
+        if (c & 0x20) x = 0;              // zx
+        if (c & 0x10) x = (~x) & MASK;    // nx
+        if (c & 0x08) y = 0;              // zy
+        if (c & 0x04) y = (~y) & MASK;    // ny
+        let out = (c & 0x02) ? ((x + y) & MASK) : (x & y);   // f
+        if (c & 0x01) out = (~out) & MASK;                   // no
+        return out;
+    }
+
+    function step() {
+        const inst = (PC < ROM.length) ? (ROM[PC] & MASK) : 0;
+        if ((inst & 0x8000) === 0) {          // A-instruction
+            A = inst & 0x7FFF;
+            PC = (PC + 1) & 0x7FFF;
+            return;
+        }
+        // C-instruction: 111 a c1..c6 d1 d2 d3 j1 j2 j3
+        const a = (inst >> 12) & 1;
+        const c = (inst >> 6) & 0x3F;
+        const y = a ? (RAM[A & 0x7FFF] & MASK) : A;
+        const out = alu(D, y, c);
+        const aOld = A;
+        if (inst & 0x08) { const addr = A & 0x7FFF; if (addr !== KBD) RAM[addr] = out; } // dest M
+        if (inst & 0x20) A = out;   // dest A
+        if (inst & 0x10) D = out;   // dest D
+        const signed = (out << 16) >> 16;
+        const zr = out === 0, ng = signed < 0;
+        const jump = ((inst & 0x04) && ng) || ((inst & 0x02) && zr) || ((inst & 0x01) && !ng && !zr);
+        PC = jump ? (aOld & 0x7FFF) : ((PC + 1) & 0x7FFF);
+    }
+
+    const canvas = document.getElementById('hackScreen');
+    const ctx = canvas.getContext('2d');
+    const img = ctx.createImageData(512, 256);
+    const buf = img.data;
+    for (let i = 0; i < buf.length; i += 4) { buf[i] = 2; buf[i + 1] = 6; buf[i + 2] = 4; buf[i + 3] = 255; }
+
+    function render() {
+        for (let row = 0; row < 256; row++) {
+            const rBase = SCREEN + row * 32;
+            const pRow = row * 512;
+            for (let wc = 0; wc < 32; wc++) {
+                const word = RAM[rBase + wc] & MASK;
+                const pixBase = (pRow + wc * 16) * 4;
+                for (let b = 0; b < 16; b++) {
+                    const on = (word >> b) & 1;
+                    const idx = pixBase + b * 4;
+                    if (on) { buf[idx] = 0; buf[idx + 1] = 255; buf[idx + 2] = 159; }
+                    else    { buf[idx] = 2; buf[idx + 1] = 6;   buf[idx + 2] = 4; }
+                }
+            }
+        }
+        ctx.putImageData(img, 0, 0);
+    }
+
+    const ipsEl = document.getElementById('emuIps');
+    const pcEl = document.getElementById('emuPc');
+    const BUDGET = 7000;   // instructions per animation frame -> playable fall speed
+
+    function frame() {
+        if (running) {
+            RAM[KBD] = key;
+            for (let i = 0; i < BUDGET; i++) step();
+            insThisSec += BUDGET;
+            render();
+            pcEl.textContent = PC;
+            const now = performance.now();
+            if (now - lastSec > 500) {
+                const ips = insThisSec / ((now - lastSec) / 1000);
+                ipsEl.textContent = (ips / 1e6).toFixed(2) + ' M instr/s';
+                insThisSec = 0; lastSec = now;
+            }
+        }
+        requestAnimationFrame(frame);
+    }
+    requestAnimationFrame(frame);
+
+    // ---- input ----
+    const KEYMAP = { ArrowLeft: 130, ArrowUp: 131, ArrowRight: 132, ArrowDown: 133, ' ': 32 };
+    let focused = false;
+    canvas.addEventListener('focus', () => focused = true);
+    canvas.addEventListener('blur', () => { focused = false; key = 0; });
+    canvas.addEventListener('click', () => canvas.focus());
+    window.addEventListener('keydown', (e) => {
+        if (!focused) return;
+        if (e.key in KEYMAP) { key = KEYMAP[e.key]; e.preventDefault(); }
+    });
+    window.addEventListener('keyup', (e) => {
+        if (!focused) return;
+        if (e.key in KEYMAP) { key = 0; e.preventDefault(); }
+    });
+
+    function holdBtn(id, code) {
+        const el = document.getElementById(id);
+        const dn = (e) => { key = code; el.classList.add('down'); e.preventDefault(); };
+        const up = () => { key = 0; el.classList.remove('down'); };
+        el.addEventListener('mousedown', dn); el.addEventListener('touchstart', dn, { passive: false });
+        el.addEventListener('mouseup', up); el.addEventListener('mouseleave', up);
+        el.addEventListener('touchend', up); el.addEventListener('touchcancel', up);
+    }
+    holdBtn('btnLeft', 130); holdBtn('btnRight', 132); holdBtn('btnDown', 133);
+    document.getElementById('btnReset').addEventListener('click', reset);
+    const pauseBtn = document.getElementById('btnPause');
+    pauseBtn.addEventListener('click', () => {
+        running = !running;
+        pauseBtn.textContent = running ? 'pause' : 'resume';
+    });
+})();
+</script>
+
+<script src="../js/diagram-zoom.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -61,6 +61,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://ajayadahal.github.io/projects/hack-computer-basys3.html</loc>
+    <lastmod>2026-09-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://ajayadahal.github.io/projects/wifi-har-versal.html</loc>
     <lastmod>2026-08-24</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
Adds a story-driven project page documenting the from-scratch build of the Nand2Tetris **Hack computer** on a Digilent Basys3.

Highlights:
- Same visual template/story structure as the other project pages (Acts, Mermaid, KaTeX, Prism, war-stories).
- A **real Hack CPU emulator in JavaScript** runs the *exact* `tetris.hex` ROM from the repo, rendered to a CRT-styled canvas and playable with the arrow keys — the same bits that run on the board.
- Covers the emulator→silicon story (synchronous block RAM, clock-enable multicycle path), VGA + PS/2 I/O, timing closure (WNS +1.74 ns @ 100 MHz), resource usage, and three war-stories.
- Adds a **Sandbox** card + SVG thumbnail on `home.html` and a `sitemap.xml` entry.

Verified: HTML tags balanced, emulator JS `node --check` clean, and the embedded ROM byte-matches the repo and runs the game correctly under a Node reference execution.