### PR TITLE
Declutter Projects section + feature WiFi HAR (Versal AI Engine)

### DIFF
--- a/home.html
+++ b/home.html
@@ -1205,6 +1205,12 @@
                             <p style="color: #666; font-size: 1.1rem;">Open-source FPGA reference designs and hardware projects spanning high-speed networking, embedded systems, and robotics.</p>
                         </div>
 
+                        <!-- ============ FEATURED WORK ============ -->
+                        <div style="margin-bottom: 28px;">
+                            <h3 style="font-size: 1.6rem; font-weight: 700; color: #1a1a1a; margin-bottom: 6px;">⭐ Featured Work</h3>
+                            <p style="color: #666; font-size: 0.98rem; font-weight: 500; margin: 0;">The projects I'm most proud of — deep, end-to-end builds validated on real silicon.</p>
+                        </div>
+
                         <!-- Featured: 72ns Gateway HFT Accelerator -->
                         <div class="row mb-5" style="margin-bottom: 50px !important;">
                             <div class="col-md-12 ftco-animate">
@@ -1270,6 +1276,76 @@
                                     <div style="display: flex; gap: 12px;">
                                         <a href="projects/72ns-gateway.html" class="btn btn-primary" style="flex: 1; text-align: center; padding: 14px; font-size: 15px; font-weight: 600; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); border: none; box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);">
                                             ⚡ View Full Technical Documentation
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Featured: WiFi HAR on Versal AI Engine -->
+                        <div class="row mb-5" style="margin-bottom: 50px !important;">
+                            <div class="col-md-12 ftco-animate">
+                                <div class="project-card" style="background: linear-gradient(135deg, rgba(44, 152, 240, 0.08) 0%, rgba(118, 75, 162, 0.08) 100%); border: 2px solid #2c98f0; border-radius: 12px; padding: 30px; box-shadow: 0 4px 16px rgba(44, 152, 240, 0.15); transition: all 0.3s ease; position: relative; overflow: hidden;">
+                                    <!-- Accent Corner Badge -->
+                                    <div style="position: absolute; top: 15px; right: 15px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 8px 16px; border-radius: 20px; font-size: 11px; font-weight: 700; letter-spacing: 1px;">
+                                        ⚡ FEATURED PROJECT
+                                    </div>
+
+                                    <div style="display: flex; align-items: center; margin-bottom: 20px;">
+                                        <div style="width: 60px; height: 60px; background: linear-gradient(135deg, #2c98f0 0%, #667eea 100%); border-radius: 12px; display: flex; align-items: center; justify-content: center; margin-right: 20px; font-size: 28px; color: white;">
+                                            📡
+                                        </div>
+                                        <div>
+                                            <span style="color: #6c757d; font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;">MASTER'S THESIS → SILICON</span>
+                                            <h3 style="margin: 5px 0; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; font-size: 28px; font-weight: 700;">
+                                                Seeing Through Walls: WiFi HAR on the Versal AI Engine
+                                            </h3>
+                                            <p style="margin: 5px 0; color: #495057; font-weight: 600; font-size: 15px;">
+                                                Device-Free Human Sensing on an AMD Versal ACAP
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <p style="color: #495057; line-height: 1.8; margin-bottom: 20px; font-size: 15px;">
+                                        The FPGA realization of my Master's thesis. Streams WiFi <strong>Channel-State-Information</strong> from a
+                                        Raspberry Pi (<strong>nexmon</strong>) into an AMD <strong>Versal VCK190</strong>, parses the UDP/CSI packets in the
+                                        <strong>Programmable Logic</strong>, and runs the STFT + activity / breathing / fall feature extraction on the
+                                        <strong>AI Engine array</strong> — turning ordinary WiFi into a room sensor. Validated <strong>bit-accurate on real
+                                        silicon</strong>, with an on-board live dashboard.
+                                    </p>
+
+                                    <!-- Key Metrics Grid -->
+                                    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(140px, 100%), 1fr)); gap: 15px; margin-bottom: 20px;">
+                                        <div style="background: white; padding: 12px; border-radius: 8px; text-align: center; border: 1px solid #e0e0e0; box-shadow: 0 2px 8px rgba(0,0,0,0.05);">
+                                            <div style="font-size: 22px; font-weight: 700; color: #2c98f0;">5.96e-8</div>
+                                            <div style="font-size: 11px; color: #666; font-weight: 600;">Max Abs Error</div>
+                                        </div>
+                                        <div style="background: white; padding: 12px; border-radius: 8px; text-align: center; border: 1px solid #e0e0e0; box-shadow: 0 2px 8px rgba(0,0,0,0.05);">
+                                            <div style="font-size: 22px; font-weight: 700; color: #667eea;">L = 256</div>
+                                            <div style="font-size: 11px; color: #666; font-weight: 600;">STFT Window</div>
+                                        </div>
+                                        <div style="background: white; padding: 12px; border-radius: 8px; text-align: center; border: 1px solid #e0e0e0; box-shadow: 0 2px 8px rgba(0,0,0,0.05);">
+                                            <div style="font-size: 22px; font-weight: 700; color: #764ba2;">3-branch</div>
+                                            <div style="font-size: 11px; color: #666; font-weight: 600;">AIE Feature Graph</div>
+                                        </div>
+                                        <div style="background: white; padding: 12px; border-radius: 8px; text-align: center; border: 1px solid #e0e0e0; box-shadow: 0 2px 8px rgba(0,0,0,0.05);">
+                                            <div style="font-size: 22px; font-weight: 700; color: #f5576c;">Silicon</div>
+                                            <div style="font-size: 11px; color: #666; font-weight: 600;">Bit-Accurate</div>
+                                        </div>
+                                    </div>
+
+                                    <div style="margin-bottom: 20px;">
+                                        <span class="tech-badge" style="display: inline-block; background: #e3f2fd; color: #1976d2; padding: 6px 14px; border-radius: 15px; font-size: 12px; margin: 4px; font-weight: 600;">Versal VCK190</span>
+                                        <span class="tech-badge" style="display: inline-block; background: #f3e5f5; color: #7b1fa2; padding: 6px 14px; border-radius: 15px; font-size: 12px; margin: 4px; font-weight: 600;">AI Engine</span>
+                                        <span class="tech-badge" style="display: inline-block; background: #fff3e0; color: #e65100; padding: 6px 14px; border-radius: 15px; font-size: 12px; margin: 4px; font-weight: 600;">WiFi CSI</span>
+                                        <span class="tech-badge" style="display: inline-block; background: #e8f5e9; color: #2e7d32; padding: 6px 14px; border-radius: 15px; font-size: 12px; margin: 4px; font-weight: 600;">nexmon</span>
+                                        <span class="tech-badge" style="display: inline-block; background: #fce4ec; color: #c2185b; padding: 6px 14px; border-radius: 15px; font-size: 12px; margin: 4px; font-weight: 600;">STFT / HAR</span>
+                                        <span class="tech-badge" style="display: inline-block; background: #f1f8e9; color: #558b2f; padding: 6px 14px; border-radius: 15px; font-size: 12px; margin: 4px; font-weight: 600;">PetaLinux</span>
+                                    </div>
+
+                                    <div style="display: flex; gap: 12px; flex-wrap: wrap;">
+                                        <a href="projects/wifi-har-versal.html" class="btn btn-primary" style="flex: 1; min-width: 200px; text-align: center; padding: 14px; font-size: 15px; font-weight: 600; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); border: none; box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);">
+                                            📡 View Full Technical Documentation
                                         </a>
                                     </div>
                                 </div>
@@ -1418,10 +1494,11 @@
                             </div>
                         </div>
 
-                        <!-- Featured AMD Reference Designs -->
-                        <div id="featured-amd" style="scroll-margin-top: 80px;">
-                            <h3 class="mb-4" style="color: #2c98f0; font-weight: 600;">Featured: AMD Xilinx Reference Designs (2023-Present)</h3>
-                        
+                        <!-- AMD Reference Designs & FPGA Engineering -->
+                        <div id="featured-amd" style="scroll-margin-top: 80px; margin-top: 20px;">
+                            <h3 class="mb-1" style="color: #2c98f0; font-weight: 600;">AMD Reference Designs &amp; FPGA Engineering</h3>
+                            <p style="color: #666; font-size: 1rem; margin-bottom: 24px;">Production AMD Versal / Zynq reference designs, reusable RTL, and the workstation that builds them (2023&ndash;present).</p>
+
                         <div class="row mb-4">
                             <!-- Versal Ethernet Project Card -->
                             <div class="col-md-6 ftco-animate">
@@ -1446,34 +1523,6 @@
                                     </div>
                                     <div style="display: flex; gap: 10px;">
                                         <a href="projects/versal-ethernet.html" class="btn btn-primary" style="flex: 1; text-align: center; padding: 10px; font-size: 14px;">
-                                            <i class="icon-github"></i> View Project
-                                        </a>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- WiFi HAR on Versal AI Engine Project Card -->
-                            <div class="col-md-6 ftco-animate">
-                                <div class="project-card" style="background: white; border: 1px solid #e0e0e0; border-radius: 10px; padding: 25px; height: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); transition: all 0.3s ease;">
-                                    <div style="display: flex; align-items: center; margin-bottom: 15px;">
-                                        <img src="skills_icon/vivado_design_suite_ml_edition.png" style="width: 50px; height: 50px; margin-right: 15px; object-fit: contain;" alt="Versal AI Engine" loading="lazy" />
-                                        <div>
-                                            <span style="color: #6c757d; font-size: 13px; font-weight: 500;">WEEKEND BUILD · THESIS → SILICON</span>
-                                            <h4 style="margin: 5px 0; color: #2c98f0; font-size: 20px; font-weight: 600;">WiFi Human-Activity Recognition on the Versal AI Engine</h4>
-                                        </div>
-                                    </div>
-                                    <p style="color: #495057; line-height: 1.6; margin-bottom: 15px;">
-                                        Streams WiFi Channel-State-Information (nexmon CSI) into a VCK190, parses the UDP/CSI packet in the PL, and runs STFT + activity / breathing / fall feature extraction on the AI Engine array. Validated bit-accurate on real silicon, with an on-board live dashboard. The FPGA realization of my Master's thesis.
-                                    </p>
-                                    <div style="margin-bottom: 15px;">
-                                        <span class="tech-badge" style="display: inline-block; background: #e3f2fd; color: #1976d2; padding: 5px 12px; border-radius: 15px; font-size: 12px; margin: 3px; font-weight: 500;">AI Engine</span>
-                                        <span class="tech-badge" style="display: inline-block; background: #e8f5e9; color: #2e7d32; padding: 5px 12px; border-radius: 15px; font-size: 12px; margin: 3px; font-weight: 500;">WiFi CSI</span>
-                                        <span class="tech-badge" style="display: inline-block; background: #fff3e0; color: #e65100; padding: 5px 12px; border-radius: 15px; font-size: 12px; margin: 3px; font-weight: 500;">nexmon</span>
-                                        <span class="tech-badge" style="display: inline-block; background: #f3e5f5; color: #7b1fa2; padding: 5px 12px; border-radius: 15px; font-size: 12px; margin: 3px; font-weight: 500;">STFT / HAR</span>
-                                        <span class="tech-badge" style="display: inline-block; background: #fce4ec; color: #c2185b; padding: 5px 12px; border-radius: 15px; font-size: 12px; margin: 3px; font-weight: 500;">PetaLinux</span>
-                                    </div>
-                                    <div style="display: flex; gap: 10px;">
-                                        <a href="projects/wifi-har-versal.html" class="btn btn-primary" style="flex: 1; text-align: center; padding: 10px; font-size: 14px;">
                                             <i class="icon-github"></i> View Project
                                         </a>
                                     </div>


### PR DESCRIPTION
Reorganizes the Projects section on `home.html` and promotes the WiFi HAR project to a featured hero card.

**Changes**
- **Feature WiFi HAR** as a full-size *Featured* hero card (matching the 72ns/SMA style) with real metrics: max abs error 5.96e-8, L=256 STFT window, 3-branch AIE feature graph, bit-accurate on silicon.
- **Remove the duplicate** small WiFi HAR card from the reference-designs row.
- **Add an '⭐ Featured Work' group heading** over the four hero cards so they read as one intentional group.
- **Relabel** `Featured: AMD Xilinx Reference Designs` → **`AMD Reference Designs & FPGA Engineering`** (accurate — the group also holds an RTL block and the EDA workstation) with a subtitle; remaining cards now sit in clean rows of two.

No other sections touched; the Hack-computer card stays in **The Sandbox**. Verified: div open/close delta is balanced (+17/+17); the pre-existing 2-tag count artifact is unchanged from before.